### PR TITLE
Fix for excessive growth of sonar.libraries property in complex multiproject setups

### DIFF
--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/configurator/ProjectConfigurator.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/configurator/ProjectConfigurator.java
@@ -26,6 +26,7 @@ import org.sonar.ide.eclipse.core.internal.SonarProperties;
 import org.sonar.ide.eclipse.core.internal.resources.ResourceUtils;
 
 import java.util.Properties;
+import java.util.Set;
 
 public abstract class ProjectConfigurator {
 
@@ -58,6 +59,19 @@ public abstract class ProjectConfigurator {
       newValue = value;
     }
     properties.put(key, newValue);
+  }
+
+  protected String concatenate(Set<String> sonarLibraries) {
+  	StringBuilder sb = new StringBuilder();
+  	boolean first = true;
+  	for (String lib : sonarLibraries) {
+  		if(!first) {
+  			sb.append(SonarProperties.SEPARATOR);
+  		}
+  		first = false;
+  		sb.append(lib);
+  	}
+  	return sb.toString();
   }
 
 }

--- a/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectContext.java
+++ b/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectContext.java
@@ -1,0 +1,50 @@
+/*
+ * Sonar Eclipse
+ * Copyright (C) 2010-2013 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.ide.eclipse.jdt.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+public class JavaProjectContext {
+
+  private final Set<String> sourceDirs = new HashSet<String>();
+  private final Set<String> testDirs = new HashSet<String>();
+  private final Set<String> libraries = new HashSet<String>();
+  private final Set<String> binaries = new HashSet<String>();
+  private final Set<IJavaProject> projects = new HashSet<IJavaProject>();
+
+  public Set<IJavaProject> getProjects() {
+    return projects;
+  }
+  public Set<String> getSourceDirs() {
+    return sourceDirs;
+  }
+  public Set<String> getTestDirs() {
+    return testDirs;
+  }
+  public Set<String> getLibraries() {
+    return libraries;
+  }
+  public Set<String> getBinaries() {
+    return binaries;
+  }
+}


### PR DESCRIPTION
In big multiproject setups with a lot of 3rd party dependencies, the sonar.libraries
 property can grow to an extent that hangs the sonar plugin.
This fix avoids this by collecting the source,test and binary folders as well as the libraries in a Set (for each) first and then generating the respective properties from that sets.
It also avoids visiting the same project multiple times which might improve performance as well.

also see http://sonar.15.x6.nabble.com/Sonar-IDE-Local-Analysis-hangs-with-complex-project-setup-td5013238.html
