### PR TITLE
Fixes for issue tracking display and tests

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/markers/MarkerUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/markers/MarkerUtilsTest.java
@@ -71,7 +71,7 @@ public class MarkerUtilsTest extends SonarTestCase {
   public void testLineStartEnd() throws Exception {
     try (TextFileContext context = new TextFileContext("src/main/java/ViolationOnFile.java")) {
       TextRange textRange = new TextRange(2);
-      FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(context.document, textRange);
+      FlatTextRange flatTextRange = MarkerUtils.getFlatTextRange(context.document, textRange);
       assertThat(flatTextRange.getStart()).isEqualTo(31);
       assertThat(flatTextRange.getEnd()).isEqualTo(63);
     }
@@ -81,7 +81,7 @@ public class MarkerUtilsTest extends SonarTestCase {
   public void testLineStartEndCrLf() throws Exception {
     try (TextFileContext context = new TextFileContext("src/main/java/ViolationOnFileCrLf.java")) {
       TextRange textRange = new TextRange(2);
-      FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(context.document, textRange);
+      FlatTextRange flatTextRange = MarkerUtils.getFlatTextRange(context.document, textRange);
       assertThat(flatTextRange.getStart()).isEqualTo(32);
       assertThat(flatTextRange.getEnd()).isEqualTo(64);
     }
@@ -91,7 +91,7 @@ public class MarkerUtilsTest extends SonarTestCase {
   public void testPreciseIssueLocationSingleLine() throws Exception {
     try (TextFileContext context = new TextFileContext("src/main/java/ViolationOnFile.java")) {
       TextRange textRange = new TextRange(2, 23, 2, 31);
-      FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(context.document, textRange);
+      FlatTextRange flatTextRange = MarkerUtils.getFlatTextRange(context.document, textRange);
       assertThat(flatTextRange.getStart()).isEqualTo(54);
       assertThat(flatTextRange.getEnd()).isEqualTo(62);
     }
@@ -101,7 +101,7 @@ public class MarkerUtilsTest extends SonarTestCase {
   public void testPreciseIssueLocationMultiLine() throws Exception {
     try (TextFileContext context = new TextFileContext("src/main/java/ViolationOnFile.java")) {
       TextRange textRange = new TextRange(4, 34, 5, 12);
-      FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(context.document, textRange);
+      FlatTextRange flatTextRange = MarkerUtils.getFlatTextRange(context.document, textRange);
       assertThat(flatTextRange.getStart()).isEqualTo(101);
       assertThat(flatTextRange.getEnd()).isEqualTo(119);
     }

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdaterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdaterTest.java
@@ -103,10 +103,26 @@ public class MarkerUpdaterTest extends SonarTestCase {
     return markers[0];
   }
 
+  /**
+   * Create a mock trackable with valid mandatory values and correct defaults.
+   *
+   * @return a mock trackable
+   */
+  private Trackable newMockTrackable() {
+    Trackable trackable = mock(Trackable.class);
+    // mandatory non-nulls
+    when(trackable.getTextRange()).thenReturn(new TextRange(1));
+    when(trackable.getSeverity()).thenReturn("");
+
+    // explicit nulls, because Mockito uses 0 values otherwise
+    when(trackable.getLine()).thenReturn(null);
+    when(trackable.getCreationDate()).thenReturn(null);
+    return trackable;
+  }
+
   @Test
   public void test_marker_of_ordinary_trackable() throws Exception {
-    Trackable trackable = mock(Trackable.class);
-    when(trackable.getTextRange()).thenReturn(new TextRange(1));
+    Trackable trackable = newMockTrackable();
 
     int priority = 2;
     String severity = "BLOCKER";
@@ -122,9 +138,6 @@ public class MarkerUpdaterTest extends SonarTestCase {
     String assignee = "admin";
     when(trackable.getAssignee()).thenReturn(assignee);
 
-    when(trackable.getLine()).thenReturn(null);
-    when(trackable.getCreationDate()).thenReturn(null);
-
     IMarker marker = processTrackable(trackable);
     assertThat(marker.getAttribute(IMarker.PRIORITY)).isEqualTo(priority);
     assertThat(marker.getAttribute(IMarker.SEVERITY)).isEqualTo(eclipseSeverity);
@@ -136,7 +149,7 @@ public class MarkerUpdaterTest extends SonarTestCase {
 
   @Test
   public void test_marker_of_trackable_with_text_range() throws Exception {
-    Trackable trackable = mock(Trackable.class);
+    Trackable trackable = newMockTrackable();
 
     int line = 5;
     when(trackable.getLine()).thenReturn(line);
@@ -151,7 +164,7 @@ public class MarkerUpdaterTest extends SonarTestCase {
 
   @Test
   public void test_marker_of_trackable_with_line() throws Exception {
-    Trackable trackable = mock(Trackable.class);
+    Trackable trackable = newMockTrackable();
 
     int line = 5;
     when(trackable.getLine()).thenReturn(line);
@@ -166,19 +179,15 @@ public class MarkerUpdaterTest extends SonarTestCase {
 
   @Test
   public void test_marker_of_trackable_without_line() throws Exception {
-    Trackable trackable = mock(Trackable.class);
-    when(trackable.getTextRange()).thenReturn(new TextRange(1));
-    when(trackable.getLine()).thenReturn(null);
-
+    Trackable trackable = newMockTrackable();
     IMarker marker = processTrackable(trackable);
-
     assertThat(marker.getAttribute(IMarker.LINE_NUMBER)).isEqualTo(1);
   }
 
   @Test
   public void test_marker_of_trackable_with_creation_date() throws Exception {
-    Trackable trackable = mock(Trackable.class);
-    when(trackable.getTextRange()).thenReturn(new TextRange(1));
+    Trackable trackable = newMockTrackable();
+
     long creationDate = System.currentTimeMillis();
     when(trackable.getCreationDate()).thenReturn(creationDate);
 
@@ -188,10 +197,7 @@ public class MarkerUpdaterTest extends SonarTestCase {
 
   @Test
   public void test_marker_of_trackable_without_creation_date() throws Exception {
-    Trackable trackable = mock(Trackable.class);
-    when(trackable.getTextRange()).thenReturn(new TextRange(1));
-    when(trackable.getCreationDate()).thenReturn(null);
-
+    Trackable trackable = newMockTrackable();
     IMarker marker = processTrackable(trackable);
     assertThat(marker.getAttribute(MarkerUtils.SONAR_MARKER_CREATION_DATE_ATTR)).isNull();
   }

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdaterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdaterTest.java
@@ -106,6 +106,7 @@ public class MarkerUpdaterTest extends SonarTestCase {
   @Test
   public void test_marker_of_ordinary_trackable() throws Exception {
     Trackable trackable = mock(Trackable.class);
+    when(trackable.getTextRange()).thenReturn(new TextRange(1));
 
     int priority = 2;
     String severity = "BLOCKER";
@@ -166,18 +167,18 @@ public class MarkerUpdaterTest extends SonarTestCase {
   @Test
   public void test_marker_of_trackable_without_line() throws Exception {
     Trackable trackable = mock(Trackable.class);
+    when(trackable.getTextRange()).thenReturn(new TextRange(1));
     when(trackable.getLine()).thenReturn(null);
 
     IMarker marker = processTrackable(trackable);
 
     assertThat(marker.getAttribute(IMarker.LINE_NUMBER)).isEqualTo(1);
-    assertThat(marker.getAttribute(IMarker.CHAR_START)).isEqualTo(null);
-    assertThat(marker.getAttribute(IMarker.CHAR_END)).isEqualTo(null);
   }
 
   @Test
   public void test_marker_of_trackable_with_creation_date() throws Exception {
     Trackable trackable = mock(Trackable.class);
+    when(trackable.getTextRange()).thenReturn(new TextRange(1));
     long creationDate = System.currentTimeMillis();
     when(trackable.getCreationDate()).thenReturn(creationDate);
 
@@ -188,6 +189,7 @@ public class MarkerUpdaterTest extends SonarTestCase {
   @Test
   public void test_marker_of_trackable_without_creation_date() throws Exception {
     Trackable trackable = mock(Trackable.class);
+    when(trackable.getTextRange()).thenReturn(new TextRange(1));
     when(trackable.getCreationDate()).thenReturn(null);
 
     IMarker marker = processTrackable(trackable);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -353,7 +353,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
     SonarLintCorePlugin.getDefault().getIssueTrackerRegistry().get(moduleKey).matchAndTrackAsNew(relativePath, trackables);
   }
 
-  private void trackServerIssues(String localModuleKey, IResource resource, String relativePath) {
+  private static void trackServerIssues(String localModuleKey, IResource resource, String relativePath) {
     String serverId = SonarLintProject.getInstance(resource).getServerId();
     if (serverId == null) {
       // not bound to a server -> nothing to do

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -323,8 +323,8 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
           SonarLintCorePlugin.getDefault().getModulePathManager().setModulePath(moduleKey, project.getLocation().toString());
 
           String relativePath = resource.getProjectRelativePath().toString();
-          trackLocalIssues(document, moduleKey, relativePath, rawIssues);
-          trackServerIssues(moduleKey, resource, relativePath);
+          trackLocalIssues(moduleKey, relativePath, document, rawIssues);
+          trackServerIssues(moduleKey, relativePath, resource);
         } finally {
           textFileBufferManager.disconnect(path, LocationKind.IFILE, new NullProgressMonitor());
         }
@@ -335,7 +335,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
     }
   }
 
-  private static void trackLocalIssues(IDocument document, String moduleKey, String relativePath, List<Issue> rawIssues) {
+  private static void trackLocalIssues(String moduleKey, String relativePath, IDocument document, List<Issue> rawIssues) {
     List<MutableTrackable> trackables = new ArrayList<>(rawIssues.size());
     for (Issue issue : rawIssues) {
       TextRange textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
@@ -353,7 +353,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
     SonarLintCorePlugin.getDefault().getIssueTrackerRegistry().get(moduleKey).matchAndTrackAsNew(relativePath, trackables);
   }
 
-  private static void trackServerIssues(String localModuleKey, IResource resource, String relativePath) {
+  private static void trackServerIssues(String localModuleKey, String relativePath, IResource resource) {
     String serverId = SonarLintProject.getInstance(resource).getServerId();
     if (serverId == null) {
       // not bound to a server -> nothing to do

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
@@ -334,16 +335,18 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
     }
   }
 
-  private static void trackLocalIssues(String moduleKey, String relativePath, IDocument document, List<Issue> rawIssues) {
+  private static void trackLocalIssues(String moduleKey, String relativePath, @Nullable IDocument document, List<Issue> rawIssues) {
     List<MutableTrackable> trackables = rawIssues.stream().map(issue -> {
       TextRange textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
       String content = null;
-      FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(document, textRange);
-      if (flatTextRange != null) {
-        try {
-          content = document.get(flatTextRange.getStart(), flatTextRange.getLength());
-        } catch (BadLocationException e) {
-          SonarLintCorePlugin.getDefault().error("failed to get text range content of file " + relativePath, e);
+      if (document != null) {
+        FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(document, textRange);
+        if (flatTextRange != null) {
+          try {
+            content = document.get(flatTextRange.getStart(), flatTextRange.getLength());
+          } catch (BadLocationException e) {
+            SonarLintCorePlugin.getDefault().error("failed to get text range content of file " + relativePath, e);
+          }
         }
       }
       return new IssueTrackable(issue, textRange, content);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -335,8 +335,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
   }
 
   private static void trackLocalIssues(String moduleKey, String relativePath, IDocument document, List<Issue> rawIssues) {
-    List<MutableTrackable> trackables = new ArrayList<>(rawIssues.size());
-    for (Issue issue : rawIssues) {
+    List<MutableTrackable> trackables = rawIssues.stream().map(issue -> {
       TextRange textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
       String content = null;
       FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(document, textRange);
@@ -347,8 +346,8 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
           SonarLintCorePlugin.getDefault().error("failed to get text range content of file " + relativePath, e);
         }
       }
-      trackables.add(new IssueTrackable(issue, textRange, content));
-    }
+      return new IssueTrackable(issue, textRange, content);
+    }).collect(Collectors.toList());
     SonarLintCorePlugin.getDefault().getIssueTrackerRegistry().get(moduleKey).matchAndTrackAsNew(relativePath, trackables);
   }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -340,7 +340,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
       TextRange textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
       String content = null;
       if (document != null) {
-        FlatTextRange flatTextRange = MarkerUtils.toFlatTextRange(document, textRange);
+        FlatTextRange flatTextRange = MarkerUtils.getFlatTextRange(document, textRange);
         if (flatTextRange != null) {
           try {
             content = document.get(flatTextRange.getStart(), flatTextRange.getLength());

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -329,8 +329,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
           textFileBufferManager.disconnect(path, LocationKind.IFILE, new NullProgressMonitor());
         }
       } else {
-        // TODO delete if this never happens, or else handle it better
-        throw new IllegalStateException("updateMarkers for not an IFile?");
+        // TODO handle non-file-level issues
       }
     }
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -298,7 +298,7 @@ public class AnalyzeProjectJob extends AbstractSonarProjectJob {
     return usedConfigurators;
   }
 
-  private void updateMarkers(Map<IResource, List<Issue>> issuesPerResource, AnalysisResults result) throws CoreException {
+  private static void updateMarkers(Map<IResource, List<Issue>> issuesPerResource, AnalysisResults result) throws CoreException {
     ITextFileBufferManager textFileBufferManager = FileBuffers.getTextFileBufferManager();
     if (textFileBufferManager == null) {
       return;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/FlatTextRange.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/FlatTextRange.java
@@ -20,19 +20,25 @@
 package org.sonarlint.eclipse.core.internal.markers;
 
 public class FlatTextRange {
-  private final Integer start;
-  private final Integer end;
+  private final int start;
+  private final int end;
+  private final int length;
 
-  public FlatTextRange(Integer start, Integer end) {
+  public FlatTextRange(int start, int end) {
     this.start = start;
     this.end = end;
+    this.length = end - start;
   }
 
-  public Integer getStart() {
+  public int getStart() {
     return start;
   }
 
-  public Integer getEnd() {
+  public int getEnd() {
     return end;
+  }
+
+  public int getLength() {
+    return length;
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/FlatTextRange.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/FlatTextRange.java
@@ -25,6 +25,9 @@ public class FlatTextRange {
   private final int length;
 
   public FlatTextRange(int start, int end) {
+    if (end < start) {
+      throw new IllegalArgumentException("start must be < end");
+    }
     this.start = start;
     this.end = end;
     this.length = end - start;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
@@ -75,7 +75,7 @@ public final class MarkerUtils {
 
   @CheckForNull
   public static FlatTextRange getFlatTextRange(final IDocument document, TextRange textRange) {
-    if (textRange == null || textRange.getStartLine() == null) {
+    if (textRange.getStartLine() == null) {
       return null;
     }
     if (textRange.getStartLineOffset() == null) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
@@ -82,7 +82,7 @@ public final class MarkerUtils {
     return toFlatTextRange(document, textRange.getStartLine(), textRange.getStartLineOffset(), textRange.getEndLine(), textRange.getEndLineOffset());
   }
 
-  public static FlatTextRange toFlatTextRange(final IDocument document, int startLine) {
+  private static FlatTextRange toFlatTextRange(final IDocument document, int startLine) {
     int startLineStartOffset;
     int length;
     String lineDelimiter;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
@@ -22,6 +22,7 @@ package org.sonarlint.eclipse.core.internal.markers;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -72,17 +73,19 @@ public final class MarkerUtils {
     }
   }
 
-  public static FlatTextRange toFlatTextRange(final IDocument document, TextRange textRange) {
+  @CheckForNull
+  public static FlatTextRange getFlatTextRange(final IDocument document, TextRange textRange) {
     if (textRange == null || textRange.getStartLine() == null) {
       return null;
     }
     if (textRange.getStartLineOffset() == null) {
-      return toFlatTextRange(document, textRange.getStartLine());
+      return getFlatTextRange(document, textRange.getStartLine());
     }
-    return toFlatTextRange(document, textRange.getStartLine(), textRange.getStartLineOffset(), textRange.getEndLine(), textRange.getEndLineOffset());
+    return getFlatTextRange(document, textRange.getStartLine(), textRange.getStartLineOffset(), textRange.getEndLine(), textRange.getEndLineOffset());
   }
 
-  private static FlatTextRange toFlatTextRange(final IDocument document, int startLine) {
+  @CheckForNull
+  private static FlatTextRange getFlatTextRange(final IDocument document, int startLine) {
     int startLineStartOffset;
     int length;
     String lineDelimiter;
@@ -102,7 +105,8 @@ public final class MarkerUtils {
     return new FlatTextRange(start, end);
   }
 
-  private static FlatTextRange toFlatTextRange(final IDocument document, int startLine, int startLineOffset, int endLine, int endLineOffset) {
+  @CheckForNull
+  private static FlatTextRange getFlatTextRange(final IDocument document, int startLine, int startLineOffset, int endLine, int endLineOffset) {
     int startLineStartOffset;
     int endLineStartOffset;
     try {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/MarkerUtils.java
@@ -91,6 +91,7 @@ public final class MarkerUtils {
       length = document.getLineLength(startLine - 1);
       lineDelimiter = document.getLineDelimiter(startLine - 1);
     } catch (BadLocationException e) {
+      SonarLintCorePlugin.getDefault().error("failed to compute flat text range for line " + startLine, e);
       return null;
     }
 
@@ -108,6 +109,7 @@ public final class MarkerUtils {
       startLineStartOffset = document.getLineOffset(startLine - 1);
       endLineStartOffset = endLine != startLine ? document.getLineOffset(endLine - 1) : startLineStartOffset;
     } catch (BadLocationException e) {
+      SonarLintCorePlugin.getDefault().error("failed to compute line offsets for start, end = " + startLine + ", " + endLine, e);
       return null;
     }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/TextRange.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/markers/TextRange.java
@@ -19,6 +19,8 @@
  */
 package org.sonarlint.eclipse.core.internal.markers;
 
+import javax.annotation.CheckForNull;
+
 public class TextRange {
 
   private final Integer startLine;
@@ -37,18 +39,22 @@ public class TextRange {
     this.endLineOffset = endLineOffset;
   }
 
+  @CheckForNull
   public Integer getStartLine() {
     return startLine;
   }
 
+  @CheckForNull
   public Integer getStartLineOffset() {
     return startLineOffset;
   }
 
+  @CheckForNull
   public Integer getEndLine() {
     return endLine;
   }
 
+  @CheckForNull
   public Integer getEndLineOffset() {
     return endLineOffset;
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/IssueTrackable.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/IssueTrackable.java
@@ -26,10 +26,12 @@ public class IssueTrackable extends MutableTrackableImpl {
 
   private final Issue issue;
   private final TextRange textRange;
+  private final Integer textRangeHash;
 
-  public IssueTrackable(Issue issue) {
+  public IssueTrackable(Issue issue, TextRange textRange, String textRangeContent) {
     this.issue = issue;
     this.textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
+    this.textRangeHash = textRangeContent != null ? textRangeContent.replaceAll("[\\s]", "").hashCode() : null;
   }
 
   @Override
@@ -44,8 +46,7 @@ public class IssueTrackable extends MutableTrackableImpl {
 
   @Override
   public Integer getTextRangeHash() {
-    // TODO Auto-generated method stub
-    return null;
+    return textRangeHash;
   }
 
   @Override

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/IssueTrackable.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/IssueTrackable.java
@@ -30,7 +30,7 @@ public class IssueTrackable extends MutableTrackableImpl {
 
   public IssueTrackable(Issue issue, TextRange textRange, String textRangeContent) {
     this.issue = issue;
-    this.textRange = new TextRange(issue.getStartLine(), issue.getStartLineOffset(), issue.getEndLine(), issue.getEndLineOffset());
+    this.textRange = textRange;
     this.textRangeHash = textRangeContent != null ? textRangeContent.replaceAll("[\\s]", "").hashCode() : null;
   }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
@@ -20,6 +20,7 @@
 package org.sonarlint.eclipse.core.internal.tracking;
 
 import java.util.Collection;
+import java.util.Locale;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
@@ -125,14 +126,16 @@ public class MarkerUpdater implements TrackingChangeListener {
    * @see IMarker.PRIORITY_LOW
    */
   private static int getPriority(final String severity) {
-    int result = IMarker.PRIORITY_LOW;
-    if ("blocker".equalsIgnoreCase(severity) || "critical".equalsIgnoreCase(severity)) {
-      result = IMarker.PRIORITY_HIGH;
-    } else if ("major".equalsIgnoreCase(severity)) {
-      result = IMarker.PRIORITY_NORMAL;
-    } else if ("minor".equalsIgnoreCase(severity) || "info".equalsIgnoreCase(severity)) {
-      result = IMarker.PRIORITY_LOW;
+    switch (severity.toLowerCase(Locale.ENGLISH)) {
+      case "blocker":
+      case "critical":
+        return IMarker.PRIORITY_HIGH;
+      case "major":
+        return IMarker.PRIORITY_NORMAL;
+      case "minor":
+      case "info":
+      default:
+        return IMarker.PRIORITY_LOW;
     }
-    return result;
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
@@ -73,9 +73,11 @@ public class MarkerUpdater implements TrackingChangeListener {
       ITextFileBuffer textFileBuffer = textFileBufferManager.getTextFileBuffer(path, LocationKind.IFILE);
       IDocument document = textFileBuffer.getDocument();
 
-      for (Trackable issue : issues) {
-        if (!issue.isResolved()) {
-          createMarker(document, file, issue);
+      if (document != null) {
+        for (Trackable issue : issues) {
+          if (!issue.isResolved()) {
+            createMarker(document, file, issue);
+          }
         }
       }
     } catch (CoreException e) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/MarkerUpdater.java
@@ -105,7 +105,7 @@ public class MarkerUpdater implements TrackingChangeListener {
     // File level issues (line == null) are displayed on line 1
     marker.setAttribute(IMarker.LINE_NUMBER, trackable.getLine() != null ? trackable.getLine() : 1);
 
-    FlatTextRange textRange = MarkerUtils.toFlatTextRange(document, trackable.getTextRange());
+    FlatTextRange textRange = MarkerUtils.getFlatTextRange(document, trackable.getTextRange());
     if (textRange != null) {
       marker.setAttribute(IMarker.CHAR_START, textRange.getStart());
       marker.setAttribute(IMarker.CHAR_END, textRange.getEnd());


### PR DESCRIPTION
Note: the PR target is not `master`, but `feature/issue-tracking`.

What should work:

- Issue tracking in standalone or connected mode, except matching by checksum (text range hash and line hash are broken at the moment)
- Hide resolved issues
- Correct marker severity display in issues view
- Correct marker display in editor view
- Correct matching by text-range-hash (only local issues have)
- Tests (travis) should pass

Regressions (prevent merging to `master`):

- Trigger analysis only on file open and on explicit command (currently Save triggers it too)
- Make `IssueTrackerCache` persistent, initialized at startup
- Clear tracking data on binding change

Other TODO:

- Improve the initialization of the per-project `IssueTracker` instances: should happen on project import / open event
- Implement matching by line hash using MD5 as on the server (is the md5 implementation osgi-ready?)
- Confirm correct resolution of module key and file path in nested maven project
- Download and store server issues on binding
- Unit tests
- Other smelly stuff (for example, `Logger` and `Console` in `org.sonarlint.eclipse.core.internal.tracking` package)