### PR TITLE
Run Analysis on Entire Project Enabled

### DIFF
--- a/org.sonarlint.eclipse.ui/plugin.xml
+++ b/org.sonarlint.eclipse.ui/plugin.xml
@@ -387,15 +387,24 @@
 	      <visibleWhen>
 	         <with variable="activeMenuSelection">
 	            <iterate ifEmpty="false">
-	              <and>
-		              <or>
-								    <adapt type="org.eclipse.core.resources.IFile"/>
-								    <adapt type="org.eclipse.core.resources.IResource">
-					      			<instanceof value="org.eclipse.core.resources.IFile"/>
-					    			</adapt>
-					  			</or>
-                 	<test property="org.sonarlint.eclipse.core.isAutoAnalysis" value="false"/>
-				  			</and>
+	              <or>
+	            		<and>
+			              		<adapt type="org.eclipse.core.resources.IProject"/>
+			              			<adapt type="org.eclipse.core.resources.IResource">
+						      			<instanceof value="org.eclipse.core.resources.IProject"/>
+						    	</adapt>
+						    	<test property="org.sonarlint.eclipse.core.isBound" value="true"/>
+					  	</and>
+	            		<and>
+		              		<or>
+			              		<adapt type="org.eclipse.core.resources.IFile"/>
+			              			<adapt type="org.eclipse.core.resources.IResource">
+						      			<instanceof value="org.eclipse.core.resources.IFile"/>
+						    	</adapt>
+					  		</or>
+                 			<test property="org.sonarlint.eclipse.core.isAutoAnalysis" value="false"/>
+				  		</and>
+	            	</or>
 	            </iterate>
 	         </with>
 	      </visibleWhen>


### PR DESCRIPTION
If user want to analysisi  entire project from eclipse then it is currently not enable, user need to open each and every file to see weather  there is any issues or not, this may useful to user to scan entire project and its really useful feature.
Discussion url for that issue is: https://groups.google.com/forum/#!msg/sonarlint/N2Qaxh58XI0/AWzg81ljAgAJ;context-place=topic/sonarlint/izf46IVhvSo