### PR TITLE
Do not crash when fail to subscribe to notifications

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -271,9 +271,13 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
   }
 
   private static void subscribeToNotifications() {
-    ProjectsProviderUtils.allProjects().stream()
-      .filter(ISonarLintProject::isBound)
-      .forEach(SonarLintUiPlugin::subscribeToNotifications);
+    try {
+      ProjectsProviderUtils.allProjects().stream()
+        .filter(ISonarLintProject::isBound)
+        .forEach(SonarLintUiPlugin::subscribeToNotifications);
+    } catch (IllegalStateException e) {
+      SonarLintLogger.get().error("Could not subscribe to notifications", e);
+    }
   }
 
   public static void subscribeToNotifications(ISonarLintProject project) {


### PR DESCRIPTION
Simple (dumb?) solution. Other alternatives considered:

- Make `Server.getConfig` wrap `StorageException` in custom exception, to catch instead of generic `IllegalStateException`. Drawback: adding API
- Run in a `Job`. Drawback: unusual to run something as a job something fast, just to defer crash in another thread