### PR TITLE
SLE-199 Hide "telemetry" and "updates check" from "progress" view

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
@@ -108,6 +108,7 @@ public class SonarLintTelemetry implements AnalysisListener {
 
     public TelemetryJob() {
       super("SonarLint Telemetry");
+      setSystem(true);
     }
 
     protected IStatus run(IProgressMonitor monitor) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/CheckForUpdatesJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/CheckForUpdatesJob.java
@@ -34,6 +34,7 @@ public class CheckForUpdatesJob extends Job {
   public CheckForUpdatesJob() {
     super("Check for configuration updates on SonarQube servers");
     setPriority(DECORATE);
+    setSystem(true);
   }
 
   @Override


### PR DESCRIPTION
As per [Platform Plug-in Developer Guide > Programmer's Guide > Runtime overview > Concurrency infrastructure > Reporting progress](http://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fruntime_jobs_progress.htm&cp=2_0_3_5_0) :

> What if your job is a low-level implementation detail that you don't want to show to users? You can flag your job as a system job. A system job is just like any other job, except the corresponding UI support will not set up a progress view or show any other UI affordances associated with running a job. If your job is not either directly initiated by a user, or a periodic task that can be configured by a user, then your job should be a system job.

So I propose to make "telemetry" and "updates check" a system jobs.

Before this change on a fresh instance of Eclipse Oxygen.2 package for Java Developers:

![before](https://user-images.githubusercontent.com/138671/35221382-36a58d88-ff7a-11e7-8a9e-37307021d3ce.png)

After this change:

![after](https://user-images.githubusercontent.com/138671/35221438-6ea6be8c-ff7a-11e7-9474-65124b95874c.png)

After this change, setting of `Show sleeping and system operations` and restart of Eclipse:

![after2](https://user-images.githubusercontent.com/138671/35221646-327f6174-ff7b-11e7-908e-e8d59316c7a4.png)
