### PR TITLE
Feature - Toggle editor change and editor open trigger

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfiguration.java
@@ -23,9 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
 import javax.annotation.Nullable;
-
 import org.sonarsource.sonarlint.core.client.api.connected.ProjectBinding;
 
 public class SonarLintProjectConfiguration {
@@ -92,7 +90,7 @@ public class SonarLintProjectConfiguration {
 
   /**
    * 
-   * @param analysisEditorTriggerEnabled
+   * @param triggerEditorOpenEnabled
    */
   public void setTriggerEditorOpenEnabled(boolean triggerEditorOpenEnabled) {
     this.triggerEditorOpenEnabled = triggerEditorOpenEnabled;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfiguration.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
+
 import org.sonarsource.sonarlint.core.client.api.connected.ProjectBinding;
 
 public class SonarLintProjectConfiguration {
@@ -33,6 +35,8 @@ public class SonarLintProjectConfiguration {
   @Nullable
   private EclipseProjectBinding projectBinding;
   private boolean autoEnabled = true;
+  private boolean triggerEditorChangeEnabled = true;
+  private boolean triggerEditorOpenEnabled = true;
 
   public List<ExclusionItem> getFileExclusions() {
     return fileExclusions;
@@ -60,6 +64,38 @@ public class SonarLintProjectConfiguration {
 
   public Optional<EclipseProjectBinding> getProjectBinding() {
     return Optional.ofNullable(projectBinding);
+  }
+
+  /**
+   * 
+   * @return
+   */
+  public boolean isTriggerEditorChangeEnabled() {
+    return triggerEditorChangeEnabled;
+  }
+
+  /**
+   * 
+   * @param triggerEditorChangeEnabled
+   */
+  public void setIsTriggerEditorChangeEnabled(boolean triggerEditorChangeEnabled) {
+    this.triggerEditorChangeEnabled = triggerEditorChangeEnabled;
+  }
+
+  /**
+   * 
+   * @return
+   */
+  public boolean isTriggerEditorOpenEnabled() {
+    return triggerEditorOpenEnabled;
+  }
+
+  /**
+   * 
+   * @param analysisEditorTriggerEnabled
+   */
+  public void setTriggerEditorOpenEnabled(boolean triggerEditorOpenEnabled) {
+    this.triggerEditorOpenEnabled = triggerEditorOpenEnabled;
   }
 
   public static class EclipseProjectBinding extends ProjectBinding {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManager.java
@@ -21,9 +21,7 @@ package org.sonarlint.eclipse.core.internal.resources;
 
 import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isBlank;
 import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isNotBlank;
-
 import java.util.List;
-
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.osgi.service.prefs.BackingStoreException;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManager.java
@@ -19,7 +19,11 @@
  */
 package org.sonarlint.eclipse.core.internal.resources;
 
+import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isBlank;
+import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isNotBlank;
+
 import java.util.List;
+
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.osgi.service.prefs.BackingStoreException;
@@ -27,9 +31,6 @@ import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfiguration.EclipseProjectBinding;
 import org.sonarlint.eclipse.core.internal.utils.PreferencesUtils;
-
-import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isBlank;
-import static org.sonarlint.eclipse.core.internal.utils.StringUtils.isNotBlank;
 
 public class SonarLintProjectConfigurationManager {
 
@@ -39,6 +40,10 @@ public class SonarLintProjectConfigurationManager {
   private static final String P_PROJECT_KEY = "projectKey";
   private static final String P_SQ_PREFIX_KEY = "sqPrefixKey";
   private static final String P_IDE_PREFIX_KEY = "idePrefixKey";
+
+  public static final String P_TRIGGER_EDITOR_CHANGE = "triggerEditorChange";
+  public static final String P_TRIGGER_EDITOR_OPEN = "triggerEditorOpen";
+
   /**
    * @deprecated since 3.7
    */
@@ -63,14 +68,18 @@ public class SonarLintProjectConfigurationManager {
     String projectKey = projectNode.get(P_PROJECT_KEY, "");
     String moduleKey = projectNode.get(P_MODULE_KEY, "");
     if (isBlank(projectKey) && isNotBlank(moduleKey)) {
-      SonarLintLogger.get().info("Project preference " + projectScope.toString() + " is outdated. Please rebind this project.");
+      SonarLintLogger.get()
+          .info("Project preference " + projectScope.toString() + " is outdated. Please rebind this project.");
     }
     projectNode.remove(P_MODULE_KEY);
     String serverId = projectNode.get(P_SERVER_ID, "");
     if (isNotBlank(serverId) && isNotBlank(projectKey)) {
-      projectConfig.setProjectBinding(new EclipseProjectBinding(serverId, projectKey, projectNode.get(P_SQ_PREFIX_KEY, ""), projectNode.get(P_IDE_PREFIX_KEY, "")));
+      projectConfig.setProjectBinding(new EclipseProjectBinding(serverId, projectKey,
+          projectNode.get(P_SQ_PREFIX_KEY, ""), projectNode.get(P_IDE_PREFIX_KEY, "")));
     }
     projectConfig.setAutoEnabled(projectNode.getBoolean(P_AUTO_ENABLED_KEY, true));
+    projectConfig.setIsTriggerEditorChangeEnabled(projectNode.getBoolean(P_TRIGGER_EDITOR_CHANGE, true));
+    projectConfig.setTriggerEditorOpenEnabled(projectNode.getBoolean(P_TRIGGER_EDITOR_OPEN, true));
     return projectConfig;
   }
 
@@ -111,6 +120,8 @@ public class SonarLintProjectConfigurationManager {
     }
 
     projectNode.putBoolean(P_AUTO_ENABLED_KEY, configuration.isAutoEnabled());
+    projectNode.putBoolean(P_TRIGGER_EDITOR_CHANGE, configuration.isTriggerEditorChangeEnabled());
+    projectNode.putBoolean(P_TRIGGER_EDITOR_OPEN, configuration.isTriggerEditorOpenEnabled());
     try {
       projectNode.flush();
       return true;

--- a/org.sonarlint.eclipse.ui/plugin.xml
+++ b/org.sonarlint.eclipse.ui/plugin.xml
@@ -571,6 +571,38 @@
 	      </visibleWhen>
 	   </command>
 	   <command
+	         commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand"
+	         style="push">
+	      <visibleWhen>
+	         <with variable="activeMenuSelection">
+	            <iterate ifEmpty="false">
+	              <or>
+							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
+									<test property="org.sonarlint.eclipse.core.open"/>
+								</adapt>
+							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
+				  			</or>
+	            </iterate>
+	         </with>
+	      </visibleWhen>
+	   </command>
+	   <command
+	         commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand"
+	         style="push">
+	      <visibleWhen>
+	         <with variable="activeMenuSelection">
+	            <iterate ifEmpty="false">
+	              <or>
+							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
+									<test property="org.sonarlint.eclipse.core.open"/>
+								</adapt>
+							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
+				  			</or>
+	            </iterate>
+	         </with>
+	      </visibleWhen>
+	   </command>		   	   
+	   <command
 	         commandId="org.sonarlint.eclipse.ui.internal.command.ExcludeCommand"
 	         style="push">
 	     <visibleWhen>
@@ -663,6 +695,18 @@
           categoryId="org.sonarlint.eclipse.ui.command.category">
     </command>
     <command
+          description="Toggle Trigger for SonarLint Analysis on Editor Change"
+          id="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand"
+          name="Toggle Editor Change Analysis"
+          categoryId="org.sonarlint.eclipse.ui.command.category">
+    </command>
+    <command
+          description="Toggle Trigger for SonarLint Analysis on Editor Open"
+          id="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand"
+          name="Toggle Editor Open Analysis"
+          categoryId="org.sonarlint.eclipse.ui.command.category">
+    </command>           
+    <command
           description="Exclude from analysis"
           id="org.sonarlint.eclipse.ui.internal.command.ExcludeCommand"
           name="Exclude"
@@ -728,6 +772,46 @@
          </enabledWhen>
     </handler>
     <handler
+          class="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand"
+          commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand">
+          <enabledWhen>
+		        <with variable="activeMenuSelection">
+		          <iterate ifEmpty="false" operator="or">
+		            <or>
+	                 <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
+		                 <not>
+		                   <test property="org.sonarlint.eclipse.core.excluded"/>
+		                 </not>
+	                 </adapt>
+	                 <not>
+	                 		<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
+	                 </not>
+                 </or>
+	         </iterate>
+		       </with>
+         </enabledWhen>
+    </handler>
+    <handler
+          class="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand"
+          commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand">
+                    <enabledWhen>
+		        <with variable="activeMenuSelection">
+		          <iterate ifEmpty="false" operator="or">
+		            <or>
+	                 <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
+		                 <not>
+		                   <test property="org.sonarlint.eclipse.core.excluded"/>
+		                 </not>
+	                 </adapt>
+	                 <not>
+	                 		<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
+	                 </not>
+                 </or>
+	         </iterate>
+		       </with>
+         </enabledWhen>
+    </handler>        
+    <handler
           class="org.sonarlint.eclipse.ui.internal.command.ExcludeCommand"
           commandId="org.sonarlint.eclipse.ui.internal.command.ExcludeCommand">
           <enabledWhen>
@@ -764,6 +848,12 @@
     <image
       commandId="org.sonarlint.eclipse.ui.internal.command.AnalyzeCommand"
       icon="icons/sonarlint-run-16x16.png" />
+    <image
+      commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand" 
+      icon=""/>
+    <image
+      commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand" 
+      icon=""/>               
     <image
       commandId="org.sonarlint.eclipse.ui.internal.command.AnalyzeChangeSetCommand"
       icon="icons/sonarlint-run-changed-16x16.png" />

--- a/org.sonarlint.eclipse.ui/plugin.xml
+++ b/org.sonarlint.eclipse.ui/plugin.xml
@@ -576,12 +576,12 @@
 	      <visibleWhen>
 	         <with variable="activeMenuSelection">
 	            <iterate ifEmpty="false">
-	              <or>
-							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
-									<test property="org.sonarlint.eclipse.core.open"/>
-								</adapt>
-							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
-				  			</or>
+					<or>
+						<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
+							<test property="org.sonarlint.eclipse.core.open"/>
+						</adapt>
+						<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
+				 	</or>
 	            </iterate>
 	         </with>
 	      </visibleWhen>
@@ -592,12 +592,12 @@
 	      <visibleWhen>
 	         <with variable="activeMenuSelection">
 	            <iterate ifEmpty="false">
-	              <or>
-							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
-									<test property="org.sonarlint.eclipse.core.open"/>
-								</adapt>
-							    <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
-				  			</or>
+					<or>
+						<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProject">
+							<test property="org.sonarlint.eclipse.core.open"/>
+						</adapt>
+						<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintProjectContainer"/>
+					</or>
 	            </iterate>
 	         </with>
 	      </visibleWhen>
@@ -776,40 +776,40 @@
           commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorChangeCommand">
           <enabledWhen>
 		        <with variable="activeMenuSelection">
-		          <iterate ifEmpty="false" operator="or">
-		            <or>
-	                 <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
-		                 <not>
-		                   <test property="org.sonarlint.eclipse.core.excluded"/>
-		                 </not>
-	                 </adapt>
-	                 <not>
-	                 		<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
-	                 </not>
-                 </or>
-	         </iterate>
+		          	<iterate ifEmpty="false" operator="or">
+		            	<or>
+	                 		<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
+		                 		<not>
+		                   			<test property="org.sonarlint.eclipse.core.excluded"/>
+		                 		</not>
+	                 		</adapt>
+	                 		<not>
+	                 			<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
+	                 		</not>
+                 		</or>
+	         		</iterate>
 		       </with>
          </enabledWhen>
     </handler>
     <handler
           class="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand"
           commandId="org.sonarlint.eclipse.ui.internal.command.ToggleTriggerEditorOpenCommand">
-                    <enabledWhen>
-		        <with variable="activeMenuSelection">
-		          <iterate ifEmpty="false" operator="or">
-		            <or>
-	                 <adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
-		                 <not>
-		                   <test property="org.sonarlint.eclipse.core.excluded"/>
-		                 </not>
-	                 </adapt>
-	                 <not>
-	                 		<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
-	                 </not>
-                 </or>
-	         </iterate>
-		       </with>
-         </enabledWhen>
+			<enabledWhen>
+				<with variable="activeMenuSelection">
+					<iterate ifEmpty="false" operator="or">
+						<or>
+							<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile">
+								<not>
+									<test property="org.sonarlint.eclipse.core.excluded"/>
+								</not>
+	                 		</adapt>
+	                 		<not>
+	                 			<adapt type="org.sonarlint.eclipse.core.resource.ISonarLintFile"/>
+	                 		</not>
+                 		</or>
+	         		</iterate>
+		       	</with>
+         	</enabledWhen>
     </handler>        
     <handler
           class="org.sonarlint.eclipse.ui.internal.command.ExcludeCommand"

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleTriggerEditorChangeCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleTriggerEditorChangeCommand.java
@@ -1,0 +1,51 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2018 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.command;
+
+import java.util.Collection;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.sonarlint.eclipse.core.internal.TriggerType;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.ui.internal.util.SelectionUtils;
+
+/**
+ * Command class for toggling the save action analysis flag of each selected
+ * project so that analysis does not occur on each save action in the Editor
+ * Window when <i>false</i>. If <i>true</i> normal behavior will continue.
+ * 
+ *
+ */
+public class ToggleTriggerEditorChangeCommand extends AbstractHandler {
+
+  /**
+   * 
+   */
+  @Override
+  public Object execute(ExecutionEvent event) throws ExecutionException {
+    Collection<ISonarLintProject> selectedProjects = SelectionUtils.allSelectedProjects(event);
+    ToggleUtils.updateToggleState(selectedProjects, TriggerType.EDITOR_CHANGE);
+
+    return null;
+  }
+
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleTriggerEditorOpenCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleTriggerEditorOpenCommand.java
@@ -1,0 +1,50 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2018 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.command;
+
+import java.util.Collection;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.sonarlint.eclipse.core.internal.TriggerType;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.ui.internal.util.SelectionUtils;
+
+/**
+ * Command class for toggling the editor open analysis flag of each selected
+ * project so that analysis does not occur on each editor window opened when
+ * <i>false</i>. If <i>true</i> normal behavior will continue.
+ *
+ */
+public class ToggleTriggerEditorOpenCommand extends AbstractHandler {
+
+  /**
+   * 
+   */
+  @Override
+  public Object execute(ExecutionEvent event) throws ExecutionException {
+    Collection<ISonarLintProject> selectedProjects = SelectionUtils.allSelectedProjects(event);
+    ToggleUtils.updateToggleState(selectedProjects, TriggerType.EDITOR_OPEN);
+
+    return null;
+  }
+
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/ToggleUtils.java
@@ -1,0 +1,162 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2018 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.command;
+
+import java.util.Collection;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.osgi.service.prefs.BackingStoreException;
+import org.sonarlint.eclipse.core.SonarLintLogger;
+import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
+import org.sonarlint.eclipse.core.internal.TriggerType;
+import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfiguration;
+import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfigurationManager;
+import org.sonarlint.eclipse.core.internal.utils.StringUtils;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+
+/**
+ * Utility class to handle the toggling of project-specific settings and
+ * persisting the in the projects preferences.
+ *
+ */
+public class ToggleUtils {
+
+  /**
+   * 
+   */
+  private ToggleUtils() {
+    // Utility class
+  }
+
+  /**
+   * Entry function for updating the state of the type specified of the passed
+   * list of projects.
+   * 
+   * @param selectedProjects
+   * @param triggerType
+   */
+  public static void updateToggleState(Collection<ISonarLintProject> selectedProjects, TriggerType triggerType) {
+    if (!selectedProjects.isEmpty()) {
+      SonarLintLogger.get().debug("Found " + selectedProjects.size() + " selected projects...");
+
+      // Loop through all the selected projects and update the state
+      for (ISonarLintProject project : selectedProjects) {
+        SonarLintLogger.get().debug("Updating analysis save trigger for - " + project.getName());
+        updateToggleState(project, triggerType);
+      }
+    } else {
+      SonarLintLogger.get().debug("No projects selected, no action will be performed");
+    }
+  }
+
+  /**
+   * Entry function for updating the state of the type specified of the passed
+   * project.
+   * 
+   * @param project
+   * @param triggerType
+   */
+  public static void updateToggleState(ISonarLintProject project, TriggerType triggerType) {
+    SonarLintProjectConfiguration projectConfig = SonarLintCorePlugin.loadConfig(project);
+
+    if (projectConfig != null) {
+      boolean currentState = getCurrentSate(projectConfig, triggerType);
+      IScopeContext projectScope = project.getScopeContext();
+      IEclipsePreferences projectNode = projectScope.getNode(SonarLintCorePlugin.PLUGIN_ID);
+
+      if (projectNode != null) {
+        updateState(projectNode, currentState, triggerType);
+      } else {
+        SonarLintLogger.get().error(
+            "Preferences for project (" + project.getName() + ") could not be determined, trigger will not be updated");
+      }
+    } else {
+      SonarLintLogger.get().error("No configuration found for selected project (" + project.getName() + ")...");
+    }
+  }
+
+  /**
+   * Update the state of the toggle type by inversing the current state and
+   * updating the Eclipse Preferences to persist the change.
+   * 
+   * @param projectNode
+   * @param currentState
+   * @param triggerType
+   */
+  private static void updateState(IEclipsePreferences projectNode, boolean currentState, TriggerType triggerType) {
+    boolean newState = !currentState;
+    String configKey = getConfigKey(triggerType);
+
+    if (StringUtils.isNotBlank(configKey)) {
+      try {
+        // Update config item with new value and flush to backing store
+        projectNode.putBoolean(configKey, newState);
+        projectNode.flush();
+
+        SonarLintLogger.get().info("Updated trigger state (" + triggerType.getName() + ") to " + newState);
+      } catch (BackingStoreException e) {
+        SonarLintLogger.get().error("Failed to persist trigger state (" + triggerType.getName() + ")", e);
+
+        // Reset state back as persisting failed
+        projectNode.putBoolean(configKey, currentState);
+      }
+    } else {
+      SonarLintLogger.get().error("Persistent preference key not found for type - " + triggerType);
+    }
+  }
+
+  /**
+   * Get the associated configuration key used for specified toggle type.
+   * 
+   * @param triggerType
+   * @return
+   */
+  private static String getConfigKey(TriggerType triggerType) {
+    switch (triggerType) {
+    case EDITOR_CHANGE:
+      return SonarLintProjectConfigurationManager.P_TRIGGER_EDITOR_CHANGE;
+    case EDITOR_OPEN:
+      return SonarLintProjectConfigurationManager.P_TRIGGER_EDITOR_OPEN;
+    default:
+      return null;
+    }
+  }
+
+  /**
+   * Get the current boolean value of the type specified in the project
+   * configuration scope.
+   * 
+   * @param projectConfig
+   * @param triggerType
+   * @return
+   */
+  private static boolean getCurrentSate(SonarLintProjectConfiguration projectConfig, TriggerType triggerType) {
+    switch (triggerType) {
+    case EDITOR_CHANGE:
+      return projectConfig.isTriggerEditorChangeEnabled();
+    case EDITOR_OPEN:
+      return projectConfig.isTriggerEditorOpenEnabled();
+    default:
+      return false;
+    }
+  }
+
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/server/actions/JobUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/server/actions/JobUtils.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-
 import javax.annotation.Nullable;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;


### PR DESCRIPTION
## Description of Problem:

Currently we have a bunch of class files in our project that exceed even 5000+ lines of code (legacy code) that takes about 20+ seconds to finish an analysis (when triggered).  In terms of making changes to these files (causing save action trigger) and opening various class files during an issue investigation the analysis gets triggered often causing the IDE the to freeze frequently causing unnecessary time to be lost.

## Console Log of Problem:

```
Trigger: EDITOR_OPEN
Clear markers on 0 excluded files
SonarLint processing file /fcbackend/src/main/java/com/fc/api/BaseApi.java...
Connected mode (using configuration of '###' in server '#########')
Starting analysis with configuration:
...
Forced to init a physical file
...
Found 382 issue(s)
Done in 27856 ms
```

```
Starting SonarLint for Eclipse 4.0.0.201810170711
Trigger: STARTUP
Clear markers on 0 excluded files
SonarLint processing file /fcbackend/src/main/java/com/fc/api/WorkflowApi.java...
Connected mode (using configuration of '###' in server '#########')
Starting analysis with configuration:
...
Forced to init a physical file
...
Check for updates from server '#########'
Found 544 issue(s)
0 entries removed from the store
Done in 34767 ms
```

## Proposed Solution:

The proposed solution would be to provide the user/developer the ability to "toggle" the `EDITOR_CHANGE `and `EDITOR_OPEN` analysis triggers.  Having this option on a per project level (part of the project's configuration) satisfies both use cases presented above.  This would mean a persisted mechanism to easily flag the state of the trigger to either `true` or `false` depending on the context of its use.  

## Changes Implemented:

1. Added two new command functions `Toggle XXX Analysis` option on project right-click view.
2. Add two new flags to the `SonarLintProjectConfiguration` class.
3. Added the mechanism to get the current state of the trigger type, inverse, and apply to the project's preferences (the toggle mechanism).
4. Added the necessary checks when an analysis is triggered that the appropriate flag is also checked to determine if the analysis should be scheduled or not.
5. Appropriate logging for both the toggling of the trigger state as well as a analysis being triggered but the state being false to provide the necessary indication of such actions.

## Further Comments:

I have not yet added the icons for the two new commands created.  I am not sure how the other icons were generated or where they we downloaded from so that is still outstanding; this will be added if the proposed solution is acceptable.

Let me know if there is any concern with my description above or my implementation displayed below in terms of how I implemented it.  I have no problem discussing this at length and any questions are welcome.  This is my first potential contribution to the sonarlint-eclipse project so if there is anything in terms of standard ways of implementation I missed please let me know.