### PR TITLE
Reduced scope of workspace operations

### DIFF
--- a/its/org.sonarlint.eclipse.its/src/org/sonarlint/eclipse/its/utils/JobHelpers.java
+++ b/its/org.sonarlint.eclipse.its/src/org/sonarlint/eclipse/its/utils/JobHelpers.java
@@ -75,6 +75,7 @@ public final class JobHelpers {
           jobs[i].join();
         }
       }
+      jobManager.join("org.sonarlint.eclipse.projectJob", null);
       workspace.run(new IWorkspaceRunnable() {
         @Override
         public void run(IProgressMonitor monitor) {
@@ -88,8 +89,9 @@ public final class JobHelpers {
     waitForBuildJobs();
   }
 
-  private static void waitForBuildJobs() {
+  private static void waitForBuildJobs() throws InterruptedException {
     waitForJobs(BuildJobMatcher.INSTANCE, 60 * 1000);
+    Job.getJobManager().join("org.sonarlint.eclipse.projectJob", null);
   }
 
   private static void waitForJobs(IJobMatcher matcher, int maxWaitMillis) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractAnalyzeProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractAnalyzeProjectJob.java
@@ -141,11 +141,13 @@ public abstract class AbstractAnalyzeProjectJob<CONFIG extends StandaloneAnalysi
         .collect(HashMap::new, (m, fWithDoc) -> m.put(fWithDoc.getFile(), fWithDoc.getDocument()), HashMap::putAll);
 
       SonarLintLogger.get().debug("Clear markers on " + excludedFiles.size() + " excluded files");
-      excludedFiles.forEach(SonarLintMarkerUpdater::clearMarkers);
+      ResourcesPlugin.getWorkspace().run(m -> {
+        excludedFiles.forEach(SonarLintMarkerUpdater::clearMarkers);
 
-      if (shouldClearReport) {
-        SonarLintMarkerUpdater.deleteAllMarkersFromReport();
-      }
+        if (shouldClearReport) {
+          SonarLintMarkerUpdater.deleteAllMarkersFromReport();
+        }
+      }, monitor);
 
       if (filesToAnalyze.isEmpty()) {
         return Status.OK_STATUS;
@@ -297,7 +299,7 @@ public abstract class AbstractAnalyzeProjectJob<CONFIG extends StandaloneAnalysi
       .filter(e -> e.getKey() instanceof ISonarLintFile)
       .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
-    trackIssues(docPerFile, successfulFiles, triggerType, monitor);
+    ResourcesPlugin.getWorkspace().run(m -> trackIssues(docPerFile, successfulFiles, triggerType, m), monitor);
   }
 
   protected void trackIssues(Map<ISonarLintFile, IDocument> docPerFile, Map<ISonarLintIssuable, List<Issue>> rawIssuesPerResource, TriggerType triggerType,

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarProjectJob.java
@@ -57,5 +57,10 @@ public abstract class AbstractSonarProjectJob extends Job {
   }
 
   protected abstract IStatus doRun(final IProgressMonitor monitor) throws CoreException;
+  
+  @Override
+  public final boolean belongsTo(Object family) {
+    return "org.sonarlint.eclipse.projectJob".equals(family);
+  }
 
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarProjectJob.java
@@ -19,7 +19,7 @@
  */
 package org.sonarlint.eclipse.core.internal.jobs;
 
-import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
@@ -27,7 +27,7 @@ import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfiguration;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 
-public abstract class AbstractSonarProjectJob extends WorkspaceJob {
+public abstract class AbstractSonarProjectJob extends Job {
 
   private final ISonarLintProject project;
   private final SonarLintProjectConfiguration config;
@@ -40,8 +40,12 @@ public abstract class AbstractSonarProjectJob extends WorkspaceJob {
   }
 
   @Override
-  public final IStatus runInWorkspace(final IProgressMonitor monitor) {
-    return doRun(monitor);
+  public final IStatus run(final IProgressMonitor monitor) {
+    try {
+      return doRun(monitor);
+    } catch (CoreException e) {
+      return e.getStatus();
+    }
   }
 
   protected ISonarLintProject getProject() {
@@ -52,6 +56,6 @@ public abstract class AbstractSonarProjectJob extends WorkspaceJob {
     return config;
   }
 
-  protected abstract IStatus doRun(final IProgressMonitor monitor);
+  protected abstract IStatus doRun(final IProgressMonitor monitor) throws CoreException;
 
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeChangedFilesJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeChangedFilesJob.java
@@ -85,7 +85,7 @@ public class AnalyzeChangedFilesJob extends WorkspaceJob {
         AnalyzeProjectRequest req = new AnalyzeProjectRequest(project, filesToAnalyze, TriggerType.MANUAL_CHANGESET);
         AbstractAnalyzeProjectJob<?> job = AbstractAnalyzeProjectJob.create(req);
         SubMonitor subMonitor = analysisMonitor.newChild(1);
-        job.runInWorkspace(subMonitor);
+        job.run(subMonitor);
         subMonitor.done();
       }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectsJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeProjectsJob.java
@@ -63,7 +63,7 @@ public class AnalyzeProjectsJob extends WorkspaceJob {
         AnalyzeProjectRequest req = new AnalyzeProjectRequest(project, entry.getValue(), TriggerType.MANUAL);
         AbstractAnalyzeProjectJob<?> job = AbstractAnalyzeProjectJob.create(req);
         SubMonitor subMonitor = analysisMonitor.newChild(1);
-        job.runInWorkspace(subMonitor);
+        job.run(subMonitor);
         subMonitor.done();
       }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AsyncServerMarkerUpdaterJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AsyncServerMarkerUpdaterJob.java
@@ -22,6 +22,7 @@ package org.sonarlint.eclipse.core.internal.jobs;
 import java.util.Collection;
 import java.util.Map;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -47,7 +48,12 @@ public class AsyncServerMarkerUpdaterJob extends AbstractSonarProjectJob {
   }
 
   @Override
-  protected IStatus doRun(IProgressMonitor monitor) {
+  protected IStatus doRun(IProgressMonitor monitor) throws CoreException {
+    ResourcesPlugin.getWorkspace().run(this::updateMarkers, monitor);
+    return Status.OK_STATUS;
+  }
+
+  private void updateMarkers(IProgressMonitor monitor) {
     for (Map.Entry<ISonarLintIssuable, Collection<Trackable>> entry : issuesPerResource.entrySet()) {
       ISonarLintIssuable issuable = entry.getKey();
       if (issuable instanceof ISonarLintFile) {
@@ -67,6 +73,5 @@ public class AsyncServerMarkerUpdaterJob extends AbstractSonarProjectJob {
         }
       }
     }
-    return Status.OK_STATUS;
   }
 }


### PR DESCRIPTION
Only run actual resource change (i.e. marker updates) within a workspace
operation to avoid blocking the autobuild during long-running analyses.

https://community.sonarsource.com/t/sonarlint-analysis-blocks-autobuild/10483

I don't think the changes can be unit tested (sensibly).