### PR TITLE
SLE-352 Improve SonarCloud usage report in telemetry

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetryTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetryTest.java
@@ -63,19 +63,12 @@ public class SonarLintTelemetryTest extends SonarTestCase {
 
   @Before
   public void start() throws Exception {
-    // Clear property that is set in the surefire arguments (see pom.xml)
-    System.clearProperty(SonarLintTelemetry.DISABLE_PROPERTY_KEY);
     this.telemetry = createTelemetry();
 
     project.open(MONITOR);
     ROOT.node(PREF_SERVERS).removeNode();
     SonarLintCorePlugin.getServersManager().stop();
     SonarLintCorePlugin.getServersManager().init();
-  }
-
-  @After
-  public void after() {
-    System.clearProperty(SonarLintTelemetry.DISABLE_PROPERTY_KEY);
   }
 
   private SonarLintTelemetry createTelemetry() {
@@ -91,11 +84,8 @@ public class SonarLintTelemetryTest extends SonarTestCase {
   }
 
   @Test
-  public void disable_property_should_disable_telemetry() throws Exception {
-    assertThat(createTelemetry().enabled()).isTrue();
-
-    System.setProperty(SonarLintTelemetry.DISABLE_PROPERTY_KEY, "true");
-    assertThat(createTelemetry().enabled()).isFalse();
+  public void telemetry_should_be_deactivated_for_tests() {
+    assertThat(SonarLintTelemetry.shouldBeActivated()).isFalse();
   }
 
   @Test

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetryTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetryTest.java
@@ -19,6 +19,13 @@
  */
 package org.sonarlint.eclipse.core.internal.telemetry;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.sonarlint.eclipse.core.internal.server.ServersManager.PREF_SERVERS;
+
 import java.nio.file.Path;
 
 import org.eclipse.core.resources.IProject;
@@ -31,20 +38,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
-import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
 import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfiguration;
 import org.sonarlint.eclipse.core.internal.resources.SonarLintProjectConfiguration.EclipseProjectBinding;
 import org.sonarlint.eclipse.core.internal.server.IServer;
 import org.sonarlint.eclipse.tests.common.SonarTestCase;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryClient;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryManager;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.sonarlint.eclipse.core.internal.server.ServersManager.PREF_SERVERS;
 
 public class SonarLintTelemetryTest extends SonarTestCase {
   private SonarLintTelemetry telemetry;
@@ -200,6 +199,13 @@ public class SonarLintTelemetryTest extends SonarTestCase {
   public void should_not_report_sonar_cloud_usage_when_project_is_bound_to_localhost() {
     addServer("localhost", "http://localhost:9000");
     bindImportedProjectToServer("localhost");
+
+    assertThat(SonarLintTelemetry.isAnyOpenProjectBoundToSonarCloud()).isFalse();
+  }
+
+  @Test
+  public void should_not_report_sonar_cloud_usage_when_sonar_cloud_server_connected_but_project_is_not_bound() {
+    addServer("sonarcloud", "https://sonarcloud.io");
 
     assertThat(SonarLintTelemetry.isAnyOpenProjectBoundToSonarCloud()).isFalse();
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/SonarLintCorePlugin.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/SonarLintCorePlugin.java
@@ -179,7 +179,7 @@ public class SonarLintCorePlugin extends Plugin {
     return getInstance().telemetry;
   }
 
-  public synchronized static ServersManager getServersManager() {
+  public static synchronized ServersManager getServersManager() {
     if (getInstance().serversManager == null) {
       getInstance().serversManager = new ServersManager();
       getInstance().serversManager.init();

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/SonarLintCorePlugin.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/SonarLintCorePlugin.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
+import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.event.AnalysisListenerManager;
 import org.sonarlint.eclipse.core.internal.extension.SonarLintExtensionTracker;
 import org.sonarlint.eclipse.core.internal.jobs.StandaloneSonarLintEngineFacade;
@@ -125,8 +126,17 @@ public class SonarLintCorePlugin extends Plugin {
 
     @Override
     public IStatus run(IProgressMonitor monitor) {
-      telemetry.init();
+      startTelemetry();
       return Status.OK_STATUS;
+    }
+
+    private void startTelemetry() {
+      if (SonarLintTelemetry.shouldBeActivated()) {
+        telemetry.init();
+      }
+      else {
+        SonarLintLogger.get().info("Telemetry disabled");
+      }
     }
   }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
@@ -21,6 +21,7 @@ package org.sonarlint.eclipse.core.internal.resources;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+
 import org.sonarlint.eclipse.core.internal.extension.SonarLintExtensionTracker;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.core.resource.ISonarLintProjectsProvider;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/server/ServersManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/server/ServersManager.java
@@ -48,7 +48,7 @@ import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarsource.sonarlint.core.client.api.connected.ConnectedGlobalConfiguration;
 
 public class ServersManager {
-  static final String PREF_SERVERS = "servers";
+  public static final String PREF_SERVERS = "servers";
   static final String AUTH_ATTRIBUTE = "auth";
   static final String URL_ATTRIBUTE = "url";
   static final String ORG_ATTRIBUTE = "org";

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
@@ -59,6 +59,10 @@ public class SonarLintTelemetry {
     return SonarLintCorePlugin.getInstance().getStateLocation().toFile().toPath().resolve(OLD_STORAGE_FILENAME);
   }
 
+  public static boolean shouldBeActivated() {
+    return !"true".equals(System.getProperty(DISABLE_PROPERTY_KEY));
+  }
+
   public void optOut(boolean optOut) {
     if (telemetry != null) {
       if (optOut) {
@@ -78,10 +82,6 @@ public class SonarLintTelemetry {
   }
 
   public void init() {
-    if ("true".equals(System.getProperty(DISABLE_PROPERTY_KEY))) {
-      SonarLintLogger.get().info("Telemetry disabled by system property");
-      return;
-    }
     try {
       TelemetryClientConfig clientConfig = getTelemetryClientConfig();
       TelemetryClient client = new TelemetryClient(clientConfig, PRODUCT, SonarLintUtils.getPluginVersion(), ideVersionForTelemetry());


### PR DESCRIPTION
We report SonarCloud usage if at least one project is bound and opened.

Previously we could report SonarCloud usage if a server connection to SC was created but no project was bound.