### PR TITLE
SLE-354 Embed mylyn dependencies in sonarlint feature.

### DIFF
--- a/org.sonarlint.eclipse.feature/feature.xml
+++ b/org.sonarlint.eclipse.feature/feature.xml
@@ -93,4 +93,39 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.mylyn.commons.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.mylyn.commons.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.mylyn.commons.screenshots"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.lang"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.guava"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.sonarlint.eclipse.site/category.xml
+++ b/org.sonarlint.eclipse.site/category.xml
@@ -19,5 +19,4 @@
          Source files when developing SonarLint integration
       </description>
    </category-def>
-   <repository-reference location="https://download.eclipse.org/mylyn/releases/latest" enabled="true" />
 </site>

--- a/org.sonarlint.eclipse.site/pom.xml
+++ b/org.sonarlint.eclipse.site/pom.xml
@@ -20,9 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <includePackedArtifacts>true</includePackedArtifacts>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,11 @@
                 <plugin id="org.sonarsource.sonarlint.core.sonarlint-core" />
                 <plugin id="com.google.protobuf" />
                 <plugin id="net.sdruskat.fragment.sun.misc" />
+                <plugin id="org.eclipse.mylyn.commons.ui" />
+                <plugin id="org.eclipse.mylyn.commons.core" />
+                <plugin id="org.eclipse.mylyn.commons.screenshots" />
+                <plugin id="org.apache.commons.lang" />
+                <plugin id="com.google.guava" />
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
This way we make sure the Mylyn dependency is always present, even on IDEs where it is not present by default and the update site might be hard to reach