### PR TITLE
Update pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -326,7 +326,12 @@ stages:
         name: mavenSettings
         inputs:
           secureFile: 'maven-settings.xml'
-      - template: prepare-sq-analysis-steps.yml
+      - task: SonarQubePrepare@5
+        name: prepareSqAnalysis
+        displayName: Prepare SonarQube analysis
+        inputs:
+          SonarQube: 'Next'
+          scannerMode: 'Other'
       - bash: |
           set -e
           sudo apt-get update
@@ -379,6 +384,9 @@ stages:
           mavenOptions: $(MAVEN_OPTS)
           sonarQubeRunAnalysis: true
           sqMavenPluginVersionChoice: 'latest'
+      - task: SonarQubePublish@5
+        inputs:
+          pollingTimeoutSec: '300'          
 - template: promote-stage.yml@commonTemplates
   parameters:
     stageDependencies:


### PR DESCRIPTION
Based on feedback from @mickael-caro-sonarsource I gave a try to update the SQ prepare task. Since there is now builtin support of Azure Pipelines in SQ, we can simplify our build and use the task directly + use the publish task. We can then remove the `prepare-sq-analysis-steps.yml` template.