### PR TITLE
fix(BUILD-1287): fix ownership to sonarlint-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/CODEOWNERS @sonarsource/sonarlint-team


### PR DESCRIPTION
Set the team `sonarlint-team` as code owner in `.github/CODEOWNERS` file.

A clear unique ownership is required. See [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact Release Engineering Team for more information.
