### PR TITLE
BUILD-1578 skip BOM under windows os

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,6 @@
           <defaultP2Metadata>false</defaultP2Metadata>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
@@ -301,6 +300,17 @@
           </plugin>          
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>skip-cyclonedx-on-windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <cyclonedx.skip>true</cyclonedx.skip>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The BOM is only required under CI and its generation takes ages under Win OS, then let's skip it by default when running under windows family OS.