### PR TITLE
SLE-525 Remove synchronization when using the connected engine

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/connected/ConnectedEngineFacade.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/connected/ConnectedEngineFacade.java
@@ -201,20 +201,16 @@ public class ConnectedEngineFacade implements IConnectedEngineFacade {
 
   private <G> Optional<G> withEngine(Function<ConnectedSonarLintEngine, G> function) {
     getOrCreateEngine();
-    synchronized (this) {
-      if (wrappedEngine != null) {
-        return Optional.ofNullable(function.apply(wrappedEngine));
-      }
+    if (wrappedEngine != null) {
+      return Optional.ofNullable(function.apply(wrappedEngine));
     }
     return Optional.empty();
   }
 
   private void doWithEngine(Consumer<ConnectedSonarLintEngine> consumer) {
     getOrCreateEngine();
-    synchronized (this) {
-      if (wrappedEngine != null) {
-        consumer.accept(wrappedEngine);
-      }
+    if (wrappedEngine != null) {
+      consumer.accept(wrappedEngine);
     }
   }
 


### PR DESCRIPTION
Since recent changes in SLCORE, the connected engine can be used by several threads at the same time