### PR TITLE
BUILD-2507 upgrade to gh-action_release v5 (5.0.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,49 +1,15 @@
 name: sonar-release
-# This workflow is triggered when publishing a new github release
 on:
   release:
     types:
       - published
 
-env:
-  PYTHONUNBUFFERED: 1
-
 jobs:
   sonar_release:
-    runs-on: ubuntu-latest
-    name: Start release process
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.BINARIES_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.BINARIES_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.BINARIES_AWS_REGION }}    
-      - name: SL release
-        id: sl_release
-        with:
-          publish_to_binaries: true
-          slack_channel: team-sonarlint-intelliclipse-notifs
-        env:
-          ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
-          BINARIES_AWS_DEPLOY: ${{ secrets.BINARIES_AWS_DEPLOY }}
-          BURGRX_USER: ${{ secrets.BURGRX_USER }}
-          BURGRX_PASSWORD: ${{ secrets.BURGRX_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        # Put your action repo here
-        uses: SonarSource/gh-action_release/main@v4
-
-      - name: Check outputs
-        if: always()
-        run: |
-          echo "${{ steps.sl_release.outputs.releasability }}"
-          echo "${{ steps.sl_release.outputs.release }}"
-      - name: Publish version on P2 update site
-        id: p2_update
-        env:
-          UPDATE_SITE_HOST: ${{secrets.UPDATE_SITE_HOST }}
-          UPDATE_SITE_SSH_USER: ${{secrets.UPDATE_SITE_SSH_USER }}
-          UPDATE_SITE_SSH_KEY: ${{secrets.UPDATE_SITE_SSH_KEY }}
-        # Put your action repo here
-        uses: SonarSource/gh-action_SL_updatep2@main
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    with:
+      publishToBinaries: true
+      slack_channel: team-sonarlint-intelliclipse-notifs


### PR DESCRIPTION
Upgrade to gh-action_release v5 (5.0.2)
- this includes onboarding on the Vault https://github.com/SonarSource/re-terraform-aws-vault/pull/440
- https://github.com/SonarSource/gh-action_release/pull/73 migrates the P2 update site to new binaries

