### PR TITLE
macOS ARM64 Support

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -212,6 +212,55 @@
         </plugins>
       </build>
     </profile>
+    
+    <!--
+    	Due to the earliest version of Eclipse for macOS on ARM64 (aarch64) being 4.22 our tests on
+    	the oldest supported version cannot be run in this environment! Therefore this profile
+    	ensures the tests will only run the oldest version with every environment but the macOS on
+    	ARM64 one.
+    	This profile can be removed in the future, when the oldest supported Eclipse version is
+    	either 4.22 or higher!
+   	-->
+    <profile>
+      <id>macOS-arm64-fix-oldest</id>
+      <activation>
+        <property>
+          <name>target.platform</name>
+          <value>oldest</value>
+        </property>
+      </activation>
+      <build>
+		<plugins>
+		  <plugin>
+	        <groupId>org.eclipse.tycho</groupId>
+	        <artifactId>target-platform-configuration</artifactId>
+	        <configuration>
+	          <target>
+	            <file>target-platforms/${target.platform}.target</file>
+	          </target>
+	          <environments>
+	            <environment>
+	              <os>win32</os>
+	              <ws>win32</ws>
+	              <arch>x86_64</arch>
+	            </environment>
+	            <environment>
+	              <os>linux</os>
+	              <ws>gtk</ws>
+	              <arch>x86_64</arch>
+	            </environment>
+	            <environment>
+	              <os>macosx</os>
+	              <ws>cocoa</ws>
+	              <arch>x86_64</arch>
+	            </environment>
+	          </environments>
+	        </configuration>
+	      </plugin>
+		</plugins>
+      </build>
+    </profile>
+    
     <profile>
       <id>full</id>
       <activation>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -123,6 +123,11 @@
             <environment>
               <os>macosx</os>
               <ws>cocoa</ws>
+              <arch>aarch64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
               <arch>x86_64</arch>
             </environment>
           </environments>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,11 @@
             <environment>
               <os>macosx</os>
               <ws>cocoa</ws>
+              <arch>aarch64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
               <arch>x86_64</arch>
             </environment>
           </environments>


### PR DESCRIPTION
## Summary

Added a new environment to both Maven main projects (parent & ITS) to support macOS on ARM64 (M1 / M2) from the command line and within the specific Eclipse IDE.
This was tested with [Amazon Corretto 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/macos-install.html) and [Amazon Correto 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/macos-install.html) installed on macOS 13.3.1 and not the builtin Java 17 JRE in Eclipse.

## Issues

Due to the only available Eclipse IDEs for macOS on ARM64 being the ones coming with Java 17 (4.22), the integration tests can not be run on the oldest Eclipse version supported in `its/target-platforms/oldest.target`.
Therefore a profile was added as an exception until the oldests supported Eclipse version is 4.22 or higher.