### PR TITLE
SLE-612: Streamline IDE / GH Wiki content for Taint Vulnerabilities

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/issues/TaintVulnerabilitiesView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/issues/TaintVulnerabilitiesView.java
@@ -44,7 +44,7 @@ public class TaintVulnerabilitiesView extends MarkerViewWithBottomPanel {
     bottom.setLayoutData(bottomLayoutData);
 
     var label = new Link(bottom, SWT.NONE);
-    label.setText("This view displays taint vulnerabilities found by SonarQube or SonarCloud on the main branch during last analysis. <a>Learn more</a>");
+    label.setText("This view displays taint vulnerabilities detected by SonarQube or SonarCloud. SonarLint does not detect those issues locally. <a>Learn more</a>");
     label.addListener(SWT.Selection, e -> {
       BrowserUtils.openExternalBrowser("https://github.com/SonarSource/sonarlint-eclipse/wiki/Taint-Vulnerabilities");
     });


### PR DESCRIPTION
## Summary

The Eclipse view "SonarLint Taint Vulnerabilities" now shows the same information text as the one shown in IntelliJ (except the terminology: In Eclipse it's a view, in IntelliJ it's a tab of the tool window).

## Additional changes outside of PR scope

Streamlining both information labels also required a change to the corresponding GitHub wiki pages. The minor changes can be viewed at:

- [SonarLint for Eclipse GitHub Wiki page "Taint Vulnerabilites"](https://github.com/SonarSource/sonarlint-eclipse/wiki/Taint-Vulnerabilities)
- [SonarLint for IntelliJ GitHub Wiki page "Taint Vulnerabilites"](https://github.com/SonarSource/sonarlint-intellij/wiki/Taint-Vulnerabilities)

A screenshot of the pages prior to the change can be found as an attachment to the Jira issue [SLE-612](https://sonarsource.atlassian.net/browse/SLE-612)!

[SLE-612]: https://sonarsource.atlassian.net/browse/SLE-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ