### PR TITLE
SLE-613: sonarlint-core 8.14 -> 8.16

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/StoragePathManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/StoragePathManager.java
@@ -35,6 +35,10 @@ public class StoragePathManager {
   private static Path getSonarLintUserHome() {
     return ResourcesPlugin.getWorkspace().getRoot().getLocation().append(".sonarlint").toFile().toPath();
   }
+  
+  public static Path getServerDefaultDir() {
+    return getSonarLintUserHome().resolve("default");
+  }
 
   public static Path getServerWorkDir(String serverId) {
     return getSonarLintUserHome().resolve("work").resolve(serverId);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/StandaloneEngineFacade.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/StandaloneEngineFacade.java
@@ -23,11 +23,11 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
+import org.sonarlint.eclipse.core.internal.StoragePathManager;
 import org.sonarlint.eclipse.core.internal.backend.PluginPathHelper;
 import org.sonarlint.eclipse.core.internal.jobs.SonarLintAnalyzerLogOutput;
 import org.sonarlint.eclipse.core.internal.jobs.WrappedProgressMonitor;
@@ -56,7 +56,7 @@ public class StandaloneEngineFacade {
       var nodeJsManager = SonarLintCorePlugin.getNodeJsManager();
       var globalConfig = StandaloneGlobalConfiguration.builder()
         .addPlugins(PluginPathHelper.getEmbeddedPluginPaths().stream().toArray(Path[]::new))
-        .setWorkDir(ResourcesPlugin.getWorkspace().getRoot().getLocation().append(".sonarlint").append("default").toFile().toPath())
+        .setWorkDir(StoragePathManager.getServerDefaultDir())
         .setLogOutput(new SonarLintAnalyzerLogOutput())
         .addEnabledLanguages(SonarLintUtils.getEnabledLanguages().toArray(new Language[0]))
         .setNodeJs(nodeJsManager.getNodeJsPath(), nodeJsManager.getNodeJsVersion())

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -97,7 +97,9 @@ public class SonarLintUtils {
   }
 
   public static Set<Language> getEnabledLanguages() {
-    var languagesDisabledByDefault = EnumSet.of(Language.JAVA, Language.CPP, Language.C, Language.OBJC, Language.SWIFT, Language.CS, Language.IPYTHON);
+    var languagesDisabledByDefault = EnumSet.of(Language.JAVA, Language.CPP, Language.C, Language.OBJC, Language.SWIFT,
+      Language.CS, Language.IPYTHON, Language.GO, Language.CLOUDFORMATION, Language.DOCKER, Language.KUBERNETES,
+      Language.TERRAFORM);
     var enabledLanguages = EnumSet.complementOf(languagesDisabledByDefault);
     var configurators = SonarLintExtensionTracker.getInstance().getAnalysisConfigurators();
     for (var configurator : configurators) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/vcs/AbstractEGitVcsFacade.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/vcs/AbstractEGitVcsFacade.java
@@ -33,7 +33,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
-import org.sonarsource.sonarlint.core.vcs.GitUtils;
+import org.sonarsource.sonarlint.core.branch.GitUtils;
 
 abstract class AbstractEGitVcsFacade implements VcsFacade {
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
@@ -63,6 +63,10 @@ import org.sonarsource.sonarlint.core.clientapi.client.host.GetHostInfoResponse;
 import org.sonarsource.sonarlint.core.clientapi.client.hotspot.HotspotDetailsDto;
 import org.sonarsource.sonarlint.core.clientapi.client.hotspot.ShowHotspotParams;
 import org.sonarsource.sonarlint.core.clientapi.client.message.ShowMessageParams;
+import org.sonarsource.sonarlint.core.clientapi.client.progress.ReportProgressParams;
+import org.sonarsource.sonarlint.core.clientapi.client.progress.StartProgressParams;
+import org.sonarsource.sonarlint.core.clientapi.client.smartnotification.ShowSmartNotificationParams;
+import org.sonarsource.sonarlint.core.clientapi.client.sync.DidSynchronizeConfigurationScopeParams;
 import org.sonarsource.sonarlint.core.commons.TextRange;
 
 public class SonarLintEclipseClient extends SonarLintEclipseHeadlessClient {
@@ -240,4 +244,21 @@ public class SonarLintEclipseClient extends SonarLintEclipseHeadlessClient {
       });
   }
 
+  // smart notifications not yet set to be handled by sonarlint-core
+  @Override
+  public void showSmartNotification(ShowSmartNotificationParams params) { }
+
+  //smart notifications not yet set to be handled by sonarlint-core
+  @Override
+  public CompletableFuture<Void> startProgress(StartProgressParams params) {
+    return null;
+  }
+
+  //smart notifications not yet set to be handled by sonarlint-core
+  @Override
+  public void reportProgress(ReportProgressParams params) { }
+
+  //smart notifications not yet set to be handled by sonarlint-core
+  @Override
+  public void didSynchronizeConfigurationScopes(DidSynchronizeConfigurationScopeParams params) { }
 }

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -17,7 +17,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
 				  <artifactId>sonarlint-core-osgi</artifactId>
-				  <version>8.14.0.63103</version>
+				  <version>8.16.0.67686</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
## Summary

Update of `sonarlint-core` from version [8.14 to 8.16](https://github.com/SonarSource/sonarlint-core/compare/8.14.0.63103...8.16.0.67686). All new flags set to the default values, as the smart notifications not yet implemented (see [SLE-609](https://sonarsource.atlassian.net/browse/SLE-609)), the newly added languages are disabled for now.
