### PR TITLE
SLE-614: Sonar property based on project settings

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
@@ -128,7 +128,7 @@ public class JdtUtilsTest extends SonarTestCase {
     var project = mock(IJavaProject.class);
     var context = mock(IPreAnalysisContext.class);
     
-    when(project.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).thenReturn("enabled");
+    when(project.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).thenReturn(JavaCore.ENABLED);
     when(project.getPath()).thenReturn(new Path(projectRoot.getAbsolutePath()));
     
     var classpath = new IClasspathEntry[] {

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
@@ -110,7 +110,7 @@ public class JdtUtilsTest extends SonarTestCase {
     
     jdtUtils.configureJavaProject(project, context);
     
-    verify(context).setAnalysisProperty("sonar.java.enablePreview", "False");
+    verify(context).setAnalysisProperty("sonar.java.enablePreview", "false");
   }
   
   /* SLE-614: Check the new Sonar property: simulate enabled by the user */
@@ -139,7 +139,7 @@ public class JdtUtilsTest extends SonarTestCase {
     
     jdtUtils.configureJavaProject(project, context);
     
-    verify(context).setAnalysisProperty("sonar.java.enablePreview", "True");
+    verify(context).setAnalysisProperty("sonar.java.enablePreview", "true");
   }
 
   @Test

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/jdt/internal/JdtUtilsTest.java
@@ -84,6 +84,63 @@ public class JdtUtilsTest extends SonarTestCase {
     verify(context).setAnalysisProperty("sonar.java.source", "1.6");
     verify(context).setAnalysisProperty("sonar.java.target", "1.6");
   }
+  
+  /* SLE-614: Check the new Sonar property: default value (either null or disabled( */
+  @Test
+  public void test_sonarJavaPreview_default() throws JavaModelException {
+    var root = ResourcesPlugin.getWorkspace().getRoot();
+    var workspaceRoot = root.getLocation().toFile();
+    var projectRoot = new File(workspaceRoot, "SLE_614_project_1");
+    projectRoot.mkdir();
+    var sourceFolder = new File(projectRoot, "src");
+    sourceFolder.mkdir();
+    var outputFolder = new File(projectRoot, "bin");
+    outputFolder.mkdirs();
+    
+    var project = mock(IJavaProject.class);
+    var context = mock(IPreAnalysisContext.class);
+    
+    when(project.getPath()).thenReturn(new Path(projectRoot.getAbsolutePath()));
+    
+    var classpath = new IClasspathEntry[] {
+      createCPE(IClasspathEntry.CPE_SOURCE, sourceFolder, outputFolder)
+    };
+    when(project.getResolvedClasspath(true)).thenReturn(classpath);
+    when(project.getOutputLocation()).thenReturn(new Path(outputFolder.getAbsolutePath()));
+    
+    jdtUtils.configureJavaProject(project, context);
+    
+    verify(context).setAnalysisProperty("sonar.java.enablePreview", "False");
+  }
+  
+  /* SLE-614: Check the new Sonar property: simulate enabled by the user */
+  @Test
+  public void test_sonarJavaPreview_changed() throws JavaModelException {
+    var root = ResourcesPlugin.getWorkspace().getRoot();
+    var workspaceRoot = root.getLocation().toFile();
+    var projectRoot = new File(workspaceRoot, "SLE_614_project_2");
+    projectRoot.mkdir();
+    var sourceFolder = new File(projectRoot, "src");
+    sourceFolder.mkdir();
+    var outputFolder = new File(projectRoot, "bin");
+    outputFolder.mkdirs();
+    
+    var project = mock(IJavaProject.class);
+    var context = mock(IPreAnalysisContext.class);
+    
+    when(project.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).thenReturn("enabled");
+    when(project.getPath()).thenReturn(new Path(projectRoot.getAbsolutePath()));
+    
+    var classpath = new IClasspathEntry[] {
+      createCPE(IClasspathEntry.CPE_SOURCE, sourceFolder, outputFolder)
+    };
+    when(project.getResolvedClasspath(true)).thenReturn(classpath);
+    when(project.getOutputLocation()).thenReturn(new Path(outputFolder.getAbsolutePath()));
+    
+    jdtUtils.configureJavaProject(project, context);
+    
+    verify(context).setAnalysisProperty("sonar.java.enablePreview", "True");
+  }
 
   @Test
   public void shouldConfigureSimpleProject() throws JavaModelException, IOException {

--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -99,8 +99,8 @@ public class JdtUtils {
     context.setAnalysisProperty("sonar.java.source", javaSource);
     context.setAnalysisProperty("sonar.java.target", javaTarget);
     
-    var javaPreview = Optional.ofNullable(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).orElse("disabled");
-    context.setAnalysisProperty("sonar.java.enablePreview", javaPreview.equalsIgnoreCase("enabled") ? "true" : "false");
+    var javaPreview = Optional.ofNullable(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).orElse(JavaCore.DISABLED);
+    context.setAnalysisProperty("sonar.java.enablePreview", javaPreview.equalsIgnoreCase(JavaCore.ENABLED) ? "true" : "false");
 
     try {
       var configuration = new JavaProjectConfiguration();

--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -97,6 +97,10 @@ public class JdtUtils {
 
     context.setAnalysisProperty("sonar.java.source", javaSource);
     context.setAnalysisProperty("sonar.java.target", javaTarget);
+    
+    var javaPreview = javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true);
+    context.setAnalysisProperty("sonar.java.enablePreview",
+      javaPreview != null && javaPreview.equalsIgnoreCase("enabled") ? "True" : "False");
 
     try {
       var configuration = new JavaProjectConfiguration();

--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -21,6 +21,7 @@ package org.sonarlint.eclipse.jdt.internal;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -98,9 +99,8 @@ public class JdtUtils {
     context.setAnalysisProperty("sonar.java.source", javaSource);
     context.setAnalysisProperty("sonar.java.target", javaTarget);
     
-    var javaPreview = javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true);
-    context.setAnalysisProperty("sonar.java.enablePreview",
-      javaPreview != null && javaPreview.equalsIgnoreCase("enabled") ? "True" : "False");
+    var javaPreview = Optional.ofNullable(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true)).orElse("disabled");
+    context.setAnalysisProperty("sonar.java.enablePreview", javaPreview.equalsIgnoreCase("enabled") ? "true" : "false");
 
     try {
       var configuration = new JavaProjectConfiguration();


### PR DESCRIPTION
## Summary

The new property "sonar.java.enablePreview" will be set automatically based on the specific project settings. If the project setting is unavailable or disabled (default or on purpose by user), the property value will be set to "False", otherwise to "True".

