### PR TITLE
SLE-615: Whitelist enabled languages

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -96,11 +96,15 @@ public class SonarLintUtils {
     return newBuilder;
   }
 
+  /**
+   *  Enabled language should be consistent with https://www.sonarsource.com/products/sonarlint/features/eclipse!
+   *  Exceptions are: - C/C++ only available with CDT (see CProjectConfiguratorExtension.whitelistedLanguages)
+   *                  - Java only available with JDT (see JavaProjectConfiguratorExtension.whitelistedLanguages)
+   */
   public static Set<Language> getEnabledLanguages() {
-    var languagesDisabledByDefault = EnumSet.of(Language.JAVA, Language.CPP, Language.C, Language.OBJC, Language.SWIFT,
-      Language.CS, Language.IPYTHON, Language.GO, Language.CLOUDFORMATION, Language.DOCKER, Language.KUBERNETES,
-      Language.TERRAFORM);
-    var enabledLanguages = EnumSet.complementOf(languagesDisabledByDefault);
+    var enabledLanguages = EnumSet.of(Language.ABAP, Language.APEX, Language.CSS, Language.COBOL, Language.HTML,
+      Language.JS, Language.KOTLIN, Language.PHP, Language.PLI, Language.PLSQL, Language.PYTHON, Language.RPG,
+      Language.RUBY, Language.SCALA, Language.SECRETS, Language.TSQL, Language.TS, Language.JSP, Language.XML);
     var configurators = SonarLintExtensionTracker.getInstance().getAnalysisConfigurators();
     for (var configurator : configurators) {
       enabledLanguages.addAll(configurator.whitelistedLanguages());


### PR DESCRIPTION
## Summary

Languages are added to `sonarlint-core`, so every new language must be disabled. This change simpliefies the process and disables the the addition of an unsupported language by accedentially updating `sonarlint-core` without checking for new languages.