### PR TITLE
SLE-619: Switch to new RulesService

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/RuleDescriptionViewTest.java
+++ b/its/src/org/sonarlint/eclipse/its/RuleDescriptionViewTest.java
@@ -19,10 +19,12 @@
  */
 package org.sonarlint.eclipse.its;
 
+import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.eclipse.reddeer.workbench.impl.editor.DefaultEditor;
 import org.eclipse.reddeer.workbench.impl.editor.Marker;
 import org.junit.Test;
+import org.sonarlint.eclipse.its.reddeer.conditions.RuleDescriptionViewContainsText;
 import org.sonarlint.eclipse.its.reddeer.views.OnTheFlyView;
 import org.sonarlint.eclipse.its.reddeer.views.RuleDescriptionView;
 
@@ -51,7 +53,7 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
     onTheFlyView.selectItem(0);
     ruleDescriptionView.open();
 
-    assertThat(ruleDescriptionView.getContent()).contains("java:S106");
+    new WaitUntil(new RuleDescriptionViewContainsText(ruleDescriptionView, "java:S106"));
     assertThat(ruleDescriptionView.getContent()).contains("Sensitive data must only be logged securely");
     assertThat(ruleDescriptionView.getContent()).contains("CERT, ERR02-J");
   }

--- a/its/src/org/sonarlint/eclipse/its/reddeer/conditions/RuleDescriptionViewContainsText.java
+++ b/its/src/org/sonarlint/eclipse/its/reddeer/conditions/RuleDescriptionViewContainsText.java
@@ -1,0 +1,38 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.reddeer.conditions;
+
+import org.eclipse.reddeer.common.condition.AbstractWaitCondition;
+import org.sonarlint.eclipse.its.reddeer.views.RuleDescriptionView;
+
+public class RuleDescriptionViewContainsText extends AbstractWaitCondition {
+  private final RuleDescriptionView ruleDescriptionView;
+  private String text;
+
+  public RuleDescriptionViewContainsText(RuleDescriptionView ruleDescriptionView, String text) {
+    this.ruleDescriptionView = ruleDescriptionView;
+    this.text = text;
+  }
+
+  @Override
+  public boolean test() {
+    return ruleDescriptionView.getContent().contains(text);
+  }
+}

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -38,6 +38,7 @@ import org.sonarlint.eclipse.core.internal.engine.connected.IConnectedEngineFaca
 import org.sonarlint.eclipse.core.internal.jobs.GlobalLogOutput;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarsource.sonarlint.core.SonarLintBackendImpl;
 import org.sonarsource.sonarlint.core.clientapi.SonarLintBackend;
 import org.sonarsource.sonarlint.core.clientapi.SonarLintClient;
@@ -46,6 +47,10 @@ import org.sonarsource.sonarlint.core.clientapi.backend.InitializeParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.connection.config.SonarCloudConnectionConfigurationDto;
 import org.sonarsource.sonarlint.core.clientapi.backend.connection.config.SonarQubeConnectionConfigurationDto;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsResponse;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionResponse;
 import org.sonarsource.sonarlint.core.commons.Language;
 
 import static java.util.Objects.requireNonNull;
@@ -156,6 +161,39 @@ public class SonarLintBackendService {
       ideName = defaultString(product.getName(), "Eclipse");
     }
     return ideName;
+  }
+
+  /**
+   *  Get the rules details (global configuration)
+   *
+   *  @param ruleKey identifier of the rule
+   *  @return
+   *  @throws InterruptedException
+   *  @throws ExecutionException
+   */
+  public GetStandaloneRuleDescriptionResponse getStandaloneRuleDetails(String ruleKey) throws InterruptedException, ExecutionException {
+    return getBackend()
+      .getRulesService()
+      .getStandaloneRuleDetails(new GetStandaloneRuleDescriptionParams(ruleKey))
+      .get();
+  }
+
+  /**
+   *  Get the rules details (project configuration, maybe connected mode)
+   *
+   *  @param project current project
+   *  @param ruleKey identifier of the rule
+   *  @param contextKey identifier of the possible connection
+   *  @return
+   *  @throws InterruptedException
+   *  @throws ExecutionException
+   */
+  public GetEffectiveRuleDetailsResponse getEffectiveRuleDetails(ISonarLintProject project, String ruleKey, String contextKey)
+    throws InterruptedException, ExecutionException {
+    return getBackend()
+      .getRulesService()
+      .getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams(ConfigScopeSynchronizer.getConfigScopeId(project), ruleKey, contextKey))
+      .get();
   }
 
   public void stop() {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -163,35 +163,17 @@ public class SonarLintBackendService {
     return ideName;
   }
 
-  /**
-   *  Get the rules details (global configuration)
-   *
-   *  @param ruleKey identifier of the rule
-   *  @return
-   *  @throws InterruptedException
-   *  @throws ExecutionException
-   *  @throws TimeoutException
-   */
-  public GetStandaloneRuleDescriptionResponse getStandaloneRuleDetails(String ruleKey) throws InterruptedException, ExecutionException, TimeoutException {
+  /** Get the rules details (global configuration) */
+  public GetStandaloneRuleDescriptionResponse getStandaloneRuleDetails(String ruleKey) throws InterruptedException, ExecutionException {
     return getBackend()
       .getRulesService()
       .getStandaloneRuleDetails(new GetStandaloneRuleDescriptionParams(ruleKey))
       .get();
   }
 
-  /**
-   *  Get the rules details (project configuration, maybe connected mode)
-   *
-   *  @param project current project
-   *  @param ruleKey identifier of the rule
-   *  @param contextKey identifier of the possible connection
-   *  @return
-   *  @throws InterruptedException
-   *  @throws ExecutionException
-   *  @throws TimeoutException
-   */
-  public GetEffectiveRuleDetailsResponse getEffectiveRuleDetails(ISonarLintProject project, String ruleKey, String contextKey)
-    throws InterruptedException, ExecutionException, TimeoutException {
+  /** Get the rules details (project configuration, maybe connected mode) */
+  public GetEffectiveRuleDetailsResponse getEffectiveRuleDetails(ISonarLintProject project, String ruleKey, @Nullable String contextKey)
+    throws InterruptedException, ExecutionException {
     return getBackend()
       .getRulesService()
       .getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams(ConfigScopeSynchronizer.getConfigScopeId(project), ruleKey, contextKey))

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -170,12 +170,13 @@ public class SonarLintBackendService {
    *  @return
    *  @throws InterruptedException
    *  @throws ExecutionException
+   *  @throws TimeoutException
    */
-  public GetStandaloneRuleDescriptionResponse getStandaloneRuleDetails(String ruleKey) throws InterruptedException, ExecutionException {
+  public GetStandaloneRuleDescriptionResponse getStandaloneRuleDetails(String ruleKey) throws InterruptedException, ExecutionException, TimeoutException {
     return getBackend()
       .getRulesService()
       .getStandaloneRuleDetails(new GetStandaloneRuleDescriptionParams(ruleKey))
-      .get();
+      .get(500, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -187,13 +188,14 @@ public class SonarLintBackendService {
    *  @return
    *  @throws InterruptedException
    *  @throws ExecutionException
+   *  @throws TimeoutException
    */
   public GetEffectiveRuleDetailsResponse getEffectiveRuleDetails(ISonarLintProject project, String ruleKey, String contextKey)
-    throws InterruptedException, ExecutionException {
+    throws InterruptedException, ExecutionException, TimeoutException {
     return getBackend()
       .getRulesService()
       .getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams(ConfigScopeSynchronizer.getConfigScopeId(project), ruleKey, contextKey))
-      .get();
+      .get(500, TimeUnit.MILLISECONDS);
   }
 
   public void stop() {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -176,7 +176,7 @@ public class SonarLintBackendService {
     return getBackend()
       .getRulesService()
       .getStandaloneRuleDetails(new GetStandaloneRuleDescriptionParams(ruleKey))
-      .get(500, TimeUnit.MILLISECONDS);
+      .get();
   }
 
   /**
@@ -195,7 +195,7 @@ public class SonarLintBackendService {
     return getBackend()
       .getRulesService()
       .getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams(ConfigScopeSynchronizer.getConfigScopeId(project), ruleKey, contextKey))
-      .get(500, TimeUnit.MILLISECONDS);
+      .get();
   }
 
   public void stop() {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarGlobalConfigurationJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarGlobalConfigurationJob.java
@@ -19,31 +19,14 @@
  */
 package org.sonarlint.eclipse.core.internal.jobs;
 
-import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
-import org.sonarlint.eclipse.core.internal.preferences.SonarLintProjectConfiguration;
-import org.sonarlint.eclipse.core.resource.ISonarLintProject;
-
-/** Base class for all jobs running at a project level */
-public abstract class AbstractSonarProjectJob extends AbstractSonarJob {
-  private final ISonarLintProject project;
-  private final SonarLintProjectConfiguration config;
-
-  public AbstractSonarProjectJob(String title, ISonarLintProject project) {
+/** Base class for all jobs running at a Eclipse global configuration level */
+public abstract class AbstractSonarGlobalConfigurationJob extends AbstractSonarJob {
+  public AbstractSonarGlobalConfigurationJob(String title) {
     super(title);
-    this.project = project;
-    this.config = SonarLintCorePlugin.loadConfig(project);
-  }
-
-  protected ISonarLintProject getProject() {
-    return project;
-  }
-
-  public SonarLintProjectConfiguration getProjectConfig() {
-    return config;
   }
 
   @Override
   public final boolean belongsTo(Object family) {
-    return "org.sonarlint.eclipse.projectJob".equals(family);
+    return "org.sonarlint.eclipse.globalConfigurationJob".equals(family);
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AbstractSonarJob.java
@@ -19,31 +19,26 @@
  */
 package org.sonarlint.eclipse.core.internal.jobs;
 
-import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
-import org.sonarlint.eclipse.core.internal.preferences.SonarLintProjectConfiguration;
-import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.jobs.Job;
 
-/** Base class for all jobs running at a project level */
-public abstract class AbstractSonarProjectJob extends AbstractSonarJob {
-  private final ISonarLintProject project;
-  private final SonarLintProjectConfiguration config;
-
-  public AbstractSonarProjectJob(String title, ISonarLintProject project) {
+/** Base class for all SonarLint jobs, for level specific jobs see subclasses */
+public abstract class AbstractSonarJob extends Job {
+  public AbstractSonarJob(String title) {
     super(title);
-    this.project = project;
-    this.config = SonarLintCorePlugin.loadConfig(project);
-  }
-
-  protected ISonarLintProject getProject() {
-    return project;
-  }
-
-  public SonarLintProjectConfiguration getProjectConfig() {
-    return config;
+    setPriority(Job.DECORATE);
   }
 
   @Override
-  public final boolean belongsTo(Object family) {
-    return "org.sonarlint.eclipse.projectJob".equals(family);
+  public final IStatus run(final IProgressMonitor monitor) {
+    try {
+      return doRun(monitor);
+    } catch (CoreException e) {
+      return e.getStatus();
+    }
   }
+
+  protected abstract IStatus doRun(final IProgressMonitor monitor) throws CoreException;
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayGlobalConfigurationRuleDescriptionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayGlobalConfigurationRuleDescriptionJob.java
@@ -42,13 +42,14 @@ public class DisplayGlobalConfigurationRuleDescriptionJob extends AbstractSonarG
 
   @Override
   protected IStatus doRun(IProgressMonitor monitor) throws CoreException {
-    Display.getDefault().syncExec(() -> {
-      try {
-        browser.updateRule(SonarLintBackendService.get().getStandaloneRuleDetails(ruleKey));
-      } catch (Exception e) {
-        SonarLintLogger.get().error("Unable to display global configuration rule description for rule " + ruleKey, e);
-      }
-    });
+    try {
+      // Getting the CompletableFuture<...> object before running the UI update to not block the UI thread
+      var ruleDetails = SonarLintBackendService.get().getStandaloneRuleDetails(ruleKey);
+      Display.getDefault().syncExec(() -> browser.updateRule(ruleDetails));
+    } catch (Exception e) {
+      SonarLintLogger.get().error("Unable to display global configuration rule description for rule " + ruleKey, e);
+      Display.getDefault().syncExec(browser::clearRule);
+    }
 
     return Status.OK_STATUS;
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayGlobalConfigurationRuleDescriptionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayGlobalConfigurationRuleDescriptionJob.java
@@ -19,42 +19,37 @@
  */
 package org.sonarlint.eclipse.ui.internal.job;
 
-import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.SonarLintLogger;
-import org.sonarlint.eclipse.core.internal.engine.connected.ResolvedBinding;
-import org.sonarlint.eclipse.core.internal.jobs.AbstractSonarProjectJob;
-import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
+import org.sonarlint.eclipse.core.internal.jobs.AbstractSonarGlobalConfigurationJob;
 import org.sonarlint.eclipse.ui.internal.util.SonarLintRuleBrowser;
 
-public class AsyncDisplayRuleDescriptionJob extends AbstractSonarProjectJob {
-  private final ResolvedBinding binding;
+/** Update "web browser" view for the global configuration rule description in a separate thread */
+public class DisplayGlobalConfigurationRuleDescriptionJob extends AbstractSonarGlobalConfigurationJob {
   private final String ruleKey;
   private final SonarLintRuleBrowser browser;
 
-  public AsyncDisplayRuleDescriptionJob(ISonarLintProject project, ResolvedBinding binding, String ruleKey, SonarLintRuleBrowser browser) {
-    super("Fetching rule description for rule '" + ruleKey + "'...", project);
-    this.binding = binding;
+  public DisplayGlobalConfigurationRuleDescriptionJob(String ruleKey, SonarLintRuleBrowser browser) {
+    super("Fetching rule description for rule '" + ruleKey + "'...");
     this.ruleKey = ruleKey;
     this.browser = browser;
   }
 
   @Override
   protected IStatus doRun(IProgressMonitor monitor) throws CoreException {
-    try {
-      var ruleDetails = binding.getEngineFacade().getRuleDescription(ruleKey, binding.getProjectBinding().projectKey()).get(1, TimeUnit.MINUTES);
-      if (ruleDetails != null) {
-        Display.getDefault().syncExec(() -> browser.updateRule(ruleDetails));
-      } else {
-        SonarLintLogger.get().error("Cannot fetch rule description for rule" + ruleKey);
+    Display.getDefault().syncExec(() -> {
+      try {
+        browser.updateRule(SonarLintBackendService.get().getStandaloneRuleDetails(ruleKey));
+      } catch (Exception e) {
+        SonarLintLogger.get().error("Unable to display global configuration rule description for rule " + ruleKey, e);
       }
-    } catch (Exception e) {
-      SonarLintLogger.get().error("Unable to display rule description for rule " + ruleKey, e);
-    }
+    });
+
     return Status.OK_STATUS;
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
@@ -1,0 +1,60 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.job;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.swt.widgets.Display;
+import org.sonarlint.eclipse.core.SonarLintLogger;
+import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
+import org.sonarlint.eclipse.core.internal.jobs.AbstractSonarProjectJob;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.ui.internal.util.SonarLintRuleBrowser;
+
+/** Update "web browser" view for the project rule description (maybe context based on connection) in a separate thread */
+public class DisplayProjectRuleDescriptionJob extends AbstractSonarProjectJob {
+  private final ISonarLintProject project;
+  private final String ruleKey;
+  private final String contextKey;
+  private final SonarLintRuleBrowser browser;
+
+  public DisplayProjectRuleDescriptionJob(ISonarLintProject project, String ruleKey, String contextKey, SonarLintRuleBrowser browser) {
+    super("Fetching rule description for rule '" + ruleKey + "'...", project);
+    this.project = project;
+    this.ruleKey = ruleKey;
+    this.contextKey = contextKey;
+    this.browser = browser;
+  }
+
+  @Override
+  protected IStatus doRun(IProgressMonitor monitor) throws CoreException {
+    Display.getDefault().syncExec(() -> {
+      try {
+        browser.updateRule(SonarLintBackendService.get().getEffectiveRuleDetails(project, ruleKey, contextKey));
+      } catch (Exception e) {
+        SonarLintLogger.get().error("Unable to display project rule description for rule " + ruleKey, e);
+      }
+    });
+
+    return Status.OK_STATUS;
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
@@ -50,8 +50,13 @@ public class DisplayProjectRuleDescriptionJob extends AbstractSonarProjectJob {
     Display.getDefault().syncExec(() -> {
       try {
         browser.updateRule(SonarLintBackendService.get().getEffectiveRuleDetails(project, ruleKey, contextKey));
-      } catch (Exception e) {
-        SonarLintLogger.get().error("Unable to display project rule description for rule " + ruleKey, e);
+      } catch (Exception ignored) {
+        try {
+          // TODO: Inform the user that the rule description cannot be loaded from the connection!
+          browser.updateRule(SonarLintBackendService.get().getStandaloneRuleDetails(ruleKey));
+        } catch (Exception e) {
+          SonarLintLogger.get().error("Unable to display project rule description for rule " + ruleKey, e);
+        }
       }
     });
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/DisplayProjectRuleDescriptionJob.java
@@ -23,6 +23,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
@@ -37,7 +38,7 @@ public class DisplayProjectRuleDescriptionJob extends AbstractSonarProjectJob {
   private final String contextKey;
   private final SonarLintRuleBrowser browser;
 
-  public DisplayProjectRuleDescriptionJob(ISonarLintProject project, String ruleKey, String contextKey, SonarLintRuleBrowser browser) {
+  public DisplayProjectRuleDescriptionJob(ISonarLintProject project, String ruleKey, @Nullable String contextKey, SonarLintRuleBrowser browser) {
     super("Fetching rule description for rule '" + ruleKey + "'...", project);
     this.project = project;
     this.ruleKey = ruleKey;

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPart.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPart.java
@@ -63,6 +63,7 @@ import org.eclipse.ui.dialogs.FilteredTree;
 import org.eclipse.ui.dialogs.PatternFilter;
 import org.sonarlint.eclipse.core.internal.preferences.RuleConfig;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarlint.eclipse.ui.internal.job.DisplayGlobalConfigurationRuleDescriptionJob;
 import org.sonarlint.eclipse.ui.internal.util.SonarLintRuleBrowser;
 import org.sonarsource.sonarlint.core.client.api.common.RuleDetails;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
@@ -192,8 +193,8 @@ public class RulesConfigurationPart {
         if (!(e1 instanceof RuleDetailsWrapper && e2 instanceof RuleDetailsWrapper)) {
           return super.compare(viewer, e1, e2);
         }
-        RuleDetailsWrapper w1 = (RuleDetailsWrapper) e1;
-        RuleDetailsWrapper w2 = (RuleDetailsWrapper) e2;
+        var w1 = (RuleDetailsWrapper) e1;
+        var w2 = (RuleDetailsWrapper) e2;
         return w1.ruleDetails.getName().compareTo(w2.ruleDetails.getName());
       }
     });
@@ -212,7 +213,10 @@ public class RulesConfigurationPart {
     paramPanel.dispose();
     if (selectedNode instanceof RuleDetailsWrapper) {
       var wrapper = (RuleDetailsWrapper) selectedNode;
-      ruleBrowser.updateRule(wrapper.ruleDetails);
+
+      // Update global configuration rule description asynchronous
+      new DisplayGlobalConfigurationRuleDescriptionJob(wrapper.ruleDetails.getKey(), ruleBrowser).schedule();
+
       if (wrapper.ruleDetails.paramDetails().isEmpty()) {
         paramPanel = emptyRuleParam();
       } else {
@@ -220,7 +224,7 @@ public class RulesConfigurationPart {
         paramPanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
       }
     } else {
-      ruleBrowser.updateRule(null);
+      ruleBrowser.clearRule();
       paramPanel = emptyRuleParam();
     }
     paramPanel.requestLayout();
@@ -426,7 +430,7 @@ public class RulesConfigurationPart {
       });
     if (tree != null) {
       tree.getViewer().refresh();
-      Object currentSelection = tree.getViewer().getStructuredSelection().getFirstElement();
+      var currentSelection = tree.getViewer().getStructuredSelection().getFirstElement();
       refreshUiForRuleSelection(currentSelection);
     }
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/RuleDescriptionWebView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/RuleDescriptionWebView.java
@@ -35,11 +35,10 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 import org.sonarlint.eclipse.core.SonarLintLogger;
-import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.markers.MarkerUtils;
 import org.sonarlint.eclipse.core.resource.ISonarLintIssuable;
 import org.sonarlint.eclipse.ui.internal.SonarLintUiPlugin;
-import org.sonarlint.eclipse.ui.internal.job.AsyncDisplayRuleDescriptionJob;
+import org.sonarlint.eclipse.ui.internal.job.DisplayProjectRuleDescriptionJob;
 import org.sonarlint.eclipse.ui.internal.util.SelectionUtils;
 import org.sonarlint.eclipse.ui.internal.util.SonarLintRuleBrowser;
 
@@ -124,12 +123,8 @@ public class RuleDescriptionWebView extends ViewPart implements ISelectionListen
     if (marker != null) {
       showRuleDescription(marker);
     } else {
-      clear();
+      browser.clearRule();
     }
-  }
-
-  private void clear() {
-    browser.updateRule(null);
   }
 
   @Override
@@ -148,17 +143,8 @@ public class RuleDescriptionWebView extends ViewPart implements ISelectionListen
       return;
     }
 
-    var issuable = Adapters.adapt(element.getResource(), ISonarLintIssuable.class);
-    var project = issuable.getProject();
-
-    var resolvedBindingOpt = SonarLintCorePlugin.getServersManager().resolveBinding(project);
-    if (resolvedBindingOpt.isPresent()) {
-      new AsyncDisplayRuleDescriptionJob(project, resolvedBindingOpt.get(), ruleKey, browser).schedule();
-    } else {
-      var ruleDetails = SonarLintCorePlugin.getInstance().getDefaultSonarLintClientFacade().getRuleDescription(ruleKey);
-      browser.updateRule(ruleDetails);
-    }
-
+    // Update project rule description asynchronous
+    new DisplayProjectRuleDescriptionJob(Adapters.adapt(element.getResource(), ISonarLintIssuable.class).getProject(), ruleKey, null, browser).schedule();
   }
 
   @Override


### PR DESCRIPTION
## Summary

Switched to the new RulesService, therefore this PR is more or less a WIP. Updated the background jobs for loading the SonarLintRuleBrowser content to differ based on project / global configuration level.

## Issues

The only issue I'm currently facing is the following: Having a project opened which is bound to my local SQ instance, when analyzing a file of that project and the local SQ instance is down, the `SonarLintBackendService.getEffectiveRuleDetails` will hang in the background job as it awaits its own timeout. It doesn't know for now, that the connection might not be available at all.