### PR TITLE
Fix NPE in RuleDescriptionWebView.java

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/RuleDescriptionWebView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/views/RuleDescriptionWebView.java
@@ -140,10 +140,12 @@ public class RuleDescriptionWebView extends ViewPart implements ISelectionListen
       SonarLintLogger.get().error("No rule key on marker");
       return;
     }
-
+    ISonarLintIssuable issuable= Adapters.adapt(element.getResource(), ISonarLintIssuable.class);
+    if (issuable==null){
+      return;
+    }
     // Update project rule description asynchronous
-    new DisplayProjectRuleDescriptionJob(Adapters.adapt(
-      element.getResource(), ISonarLintIssuable.class).getProject(),
+    new DisplayProjectRuleDescriptionJob(issuable.getProject(),
       ruleKey,
       element.getAttribute(MarkerUtils.SONAR_MARKER_RULE_DESC_CONTEXT_KEY_ATTR, null),
       ruleDetailsPanel)


### PR DESCRIPTION
sporadic

```
java.lang.NullPointerException: Cannot invoke "org.sonarlint.eclipse.core.resource.ISonarLintIssuable.getProject()" because the return value of "org.eclipse.core.runtime.Adapters.adapt(Object, java.lang.Class)" is null
	at org.sonarlint.eclipse.ui.internal.views.RuleDescriptionWebView.showRuleDescription(RuleDescriptionWebView.java:146)
	at org.sonarlint.eclipse.ui.internal.views.RuleDescriptionWebView.setInput(RuleDescriptionWebView.java:124)
	at org.sonarlint.eclipse.ui.internal.views.RuleDescriptionWebView.selectionChanged(RuleDescriptionWebView.java:159)
	at org.eclipse.ui.internal.e4.compatibility.SelectionService.notifyListeners(SelectionService.java:266)
	at org.eclipse.ui.internal.e4.compatibility.SelectionService.handlePostSelectionChanged(SelectionService.java:123)
	at org.eclipse.ui.internal.e4.compatibility.SelectionService.lambda$2(SelectionService.java:78)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$3.run(SelectionAggregator.java:163)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.notifyPostListeners(SelectionAggregator.java:160)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$6.lambda$0(SelectionAggregator.java:250)
	at org.eclipse.e4.core.contexts.RunAndTrack.runExternalCode(RunAndTrack.java:59)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator$6.changed(SelectionAggregator.java:250)
	at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:105)
	at org.eclipse.e4.core.internal.contexts.EclipseContext.runAndTrack(EclipseContext.java:340)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.track(SelectionAggregator.java:236)
	at org.eclipse.e4.ui.internal.workbench.SelectionAggregator.setPart(SelectionAggregator.java:114)
	at jdk.internal.reflect.GeneratedMethodAccessor140.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	at org.eclipse.e4.core.internal.contexts.ContextObjectSupplier$ContextInjectionListener.update(ContextObjectSupplier.java:95)
	at org.eclipse.e4.core.internal.contexts.TrackableComputationExt.update(TrackableComputationExt.java:103)
	at org.eclipse.e4.core.internal.contexts.EclipseContext.processScheduled(EclipseContext.java:358)
	at org.eclipse.e4.core.internal.contexts.EclipseContext.set(EclipseContext.java:374)
	at org.eclipse.e4.core.internal.contexts.EclipseContext.activate(EclipseContext.java:661)
	at org.eclipse.e4.core.internal.contexts.EclipseContext.activateBranch(EclipseContext.java:670)
	at org.eclipse.e4.ui.internal.workbench.PartActivationHistory.activate(PartActivationHistory.java:58)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:764)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:683)
	at org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer.activate(AbstractPartRenderer.java:97)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.lambda$0(ContributedPartRenderer.java:63)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4274)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1066)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1090)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1075)
	at org.eclipse.swt.widgets.Shell.setActiveControl(Shell.java:1530)
	at org.eclipse.swt.widgets.Shell.WM_MOUSEACTIVATE(Shell.java:2463)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4787)
	at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:340)
	at org.eclipse.swt.widgets.Decorations.windowProc(Decorations.java:1478)
	at org.eclipse.swt.widgets.Shell.windowProc(Shell.java:2306)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Tree.callWindowProc(Tree.java:1484)
	at org.eclipse.swt.widgets.Tree.windowProc(Tree.java:6043)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.CallWindowProc(Native Method)
	at org.eclipse.swt.widgets.Tree.callWindowProc(Tree.java:1576)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4844)
	at org.eclipse.swt.widgets.Tree.windowProc(Tree.java:6142)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5040)
	at org.eclipse.swt.internal.win32.OS.PeekMessage(Native Method)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3655)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1155)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:643)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:550)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:171)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:402)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)

```