### PR TITLE
BUILD-2809 try gh-action_release 5.0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@7f21146bc8cc4fcd3b860eaa0df704d1efba7dd0 # future 5.0.8
     with:
       publishToBinaries: true
       slackChannel: team-sonarlint-intelliclipse-notifs


### PR DESCRIPTION
Validate future 5.0.8 release of gh-action_release that includes CloudFront invalidation of the S3 cache.