### PR TITLE
SLE-651: Hotspots with syntax highlighting

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/hotspots/HotspotsView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/hotspots/HotspotsView.java
@@ -125,7 +125,6 @@ public class HotspotsView extends ViewPart {
     createHotspotTable();
 
     var tabFolder = new TabFolder(splitter, SWT.NONE);
-    tabFolder.setLayout(new GridLayout(1, false));
 
     var riskDescriptionTab = new TabItem(tabFolder, SWT.NONE);
     riskDescriptionTab.setText("What's the risk?");
@@ -187,12 +186,15 @@ public class HotspotsView extends ViewPart {
     riskDescriptionScrolledComposite.setMinSize(
       riskDescriptionScrolledContent.computeSize(
         riskDescriptionScrolledComposite.getClientArea().width, SWT.DEFAULT));
+    riskDescriptionScrolledComposite.requestLayout();
     vulnerabilityDescriptionScrolledComposite.setMinSize(
       vulnerabilityDescriptionScrolledContent.computeSize(
         vulnerabilityDescriptionScrolledComposite.getClientArea().width, SWT.DEFAULT));
+    vulnerabilityDescriptionScrolledComposite.requestLayout();
     fixRecommendationsScrolledComposite.setMinSize(
       fixRecommendationsScrolledContent.computeSize(
         fixRecommendationsScrolledComposite.getClientArea().width, SWT.DEFAULT));
+    fixRecommendationsScrolledComposite.requestLayout();
   }
 
   @Nullable
@@ -360,7 +362,10 @@ public class HotspotsView extends ViewPart {
     fixRecommendationsContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((Label) fixRecommendationsContent).setText(NO_SECURITY_HOTSPOTS_SELECTED);
 
-    updateScrollCompositeMinSize();
+    // None of the labels is really "scrollable", therefore only update the contents!
+    riskDescriptionContent.requestLayout();
+    vulnerabilityDescriptionContent.requestLayout();
+    fixRecommendationsContent.requestLayout();
   }
 
   private void updateRule(HotspotDetailsDto details) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/hotspots/HotspotsView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/hotspots/HotspotsView.java
@@ -30,6 +30,9 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -66,10 +69,13 @@ public class HotspotsView extends ViewPart {
   private TableViewer hotspotViewer;
   private SashForm splitter;
 
-  private TabFolder tabFolder;
-  private TabItem riskDescriptionTab;
-  private TabItem vulnerabilityDescriptionTab;
-  private TabItem fixRecommendationsTab;
+  private ScrolledComposite riskDescriptionScrolledComposite;
+  private ScrolledComposite vulnerabilityDescriptionScrolledComposite;
+  private ScrolledComposite fixRecommendationsScrolledComposite;
+
+  private Composite riskDescriptionScrolledContent;
+  private Composite vulnerabilityDescriptionScrolledContent;
+  private Composite fixRecommendationsScrolledContent;
 
   private Control riskDescriptionContent;
   private Control vulnerabilityDescriptionContent;
@@ -118,20 +124,75 @@ public class HotspotsView extends ViewPart {
 
     createHotspotTable();
 
-    tabFolder = new TabFolder(splitter, SWT.NONE);
-    riskDescriptionTab = new TabItem(tabFolder, SWT.NONE);
+    var tabFolder = new TabFolder(splitter, SWT.NONE);
+    tabFolder.setLayout(new GridLayout(1, false));
+
+    var riskDescriptionTab = new TabItem(tabFolder, SWT.NONE);
     riskDescriptionTab.setText("What's the risk?");
     riskDescriptionTab.setToolTipText("Risk decription");
-    vulnerabilityDescriptionTab = new TabItem(tabFolder, SWT.NONE);
+    riskDescriptionScrolledComposite = new ScrolledComposite(tabFolder, SWT.V_SCROLL);
+    riskDescriptionScrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+    riskDescriptionScrolledComposite.setExpandHorizontal(true);
+    riskDescriptionScrolledComposite.setExpandVertical(true);
+    riskDescriptionScrolledContent = new Composite(riskDescriptionScrolledComposite, SWT.NONE);
+    riskDescriptionScrolledContent.setLayout(new GridLayout(1, false));
+    riskDescriptionScrolledComposite.setContent(riskDescriptionScrolledContent);
+    riskDescriptionTab.setControl(riskDescriptionScrolledComposite);
+
+    var vulnerabilityDescriptionTab = new TabItem(tabFolder, SWT.NONE);
     vulnerabilityDescriptionTab.setText("Are you at risk?");
     vulnerabilityDescriptionTab.setToolTipText("Vulnerability decription");
-    fixRecommendationsTab = new TabItem(tabFolder, SWT.NONE);
+    vulnerabilityDescriptionScrolledComposite = new ScrolledComposite(tabFolder, SWT.V_SCROLL);
+    vulnerabilityDescriptionScrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+    vulnerabilityDescriptionScrolledComposite.setExpandHorizontal(true);
+    vulnerabilityDescriptionScrolledComposite.setExpandVertical(true);
+    vulnerabilityDescriptionScrolledContent = new Composite(vulnerabilityDescriptionScrolledComposite, SWT.NONE);
+    vulnerabilityDescriptionScrolledContent.setLayout(new GridLayout(1, false));
+    vulnerabilityDescriptionScrolledComposite.setContent(vulnerabilityDescriptionScrolledContent);
+    vulnerabilityDescriptionTab.setControl(vulnerabilityDescriptionScrolledComposite);
+
+    var fixRecommendationsTab = new TabItem(tabFolder, SWT.NONE);
     fixRecommendationsTab.setText("How can you fix it?");
     fixRecommendationsTab.setToolTipText("Recommendations");
+    fixRecommendationsScrolledComposite = new ScrolledComposite(tabFolder, SWT.V_SCROLL);
+    fixRecommendationsScrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+    fixRecommendationsScrolledComposite.setExpandHorizontal(true);
+    fixRecommendationsScrolledComposite.setExpandVertical(true);
+    fixRecommendationsScrolledContent = new Composite(fixRecommendationsScrolledComposite, SWT.NONE);
+    fixRecommendationsScrolledContent.setLayout(new GridLayout(1, false));
+    fixRecommendationsScrolledComposite.setContent(fixRecommendationsScrolledContent);
+    fixRecommendationsTab.setControl(fixRecommendationsScrolledComposite);
+
+    updateScrollCompositeMinSize();
+    var listener = new ControlListener() {
+      @Override
+      public void controlMoved(ControlEvent e) {
+      }
+
+      @Override
+      public void controlResized(ControlEvent e) {
+        updateScrollCompositeMinSize();
+      }
+    };
+    riskDescriptionScrolledComposite.addControlListener(listener);
+    vulnerabilityDescriptionScrolledComposite.addControlListener(listener);
+    fixRecommendationsScrolledComposite.addControlListener(listener);
 
     clearRule();
 
     return form;
+  }
+
+  private void updateScrollCompositeMinSize() {
+    riskDescriptionScrolledComposite.setMinSize(
+      riskDescriptionScrolledContent.computeSize(
+        riskDescriptionScrolledComposite.getClientArea().width, SWT.DEFAULT));
+    vulnerabilityDescriptionScrolledComposite.setMinSize(
+      vulnerabilityDescriptionScrolledContent.computeSize(
+        vulnerabilityDescriptionScrolledComposite.getClientArea().width, SWT.DEFAULT));
+    fixRecommendationsScrolledComposite.setMinSize(
+      fixRecommendationsScrolledContent.computeSize(
+        fixRecommendationsScrolledComposite.getClientArea().width, SWT.DEFAULT));
   }
 
   @Nullable
@@ -281,26 +342,25 @@ public class HotspotsView extends ViewPart {
     if (riskDescriptionContent != null && !riskDescriptionContent.isDisposed()) {
       riskDescriptionContent.dispose();
     }
-    riskDescriptionContent = new Label(tabFolder, SWT.NONE);
-    riskDescriptionContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    riskDescriptionContent = new Label(riskDescriptionScrolledContent, SWT.NONE);
+    riskDescriptionContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((Label) riskDescriptionContent).setText(NO_SECURITY_HOTSPOTS_SELECTED);
-    fixRecommendationsTab.setControl(riskDescriptionContent);
 
     if (vulnerabilityDescriptionContent != null && !vulnerabilityDescriptionContent.isDisposed()) {
       vulnerabilityDescriptionContent.dispose();
     }
-    vulnerabilityDescriptionContent = new Label(tabFolder, SWT.NONE);
-    vulnerabilityDescriptionContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    vulnerabilityDescriptionContent = new Label(vulnerabilityDescriptionScrolledContent, SWT.NONE);
+    vulnerabilityDescriptionContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((Label) vulnerabilityDescriptionContent).setText(NO_SECURITY_HOTSPOTS_SELECTED);
-    vulnerabilityDescriptionTab.setControl(vulnerabilityDescriptionContent);
 
     if (fixRecommendationsContent != null && !fixRecommendationsContent.isDisposed()) {
       fixRecommendationsContent.dispose();
     }
-    fixRecommendationsContent = new Label(tabFolder, SWT.NONE);
-    fixRecommendationsContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    fixRecommendationsContent = new Label(fixRecommendationsScrolledContent, SWT.NONE);
+    fixRecommendationsContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((Label) fixRecommendationsContent).setText(NO_SECURITY_HOTSPOTS_SELECTED);
-    fixRecommendationsTab.setControl(fixRecommendationsContent);
+
+    updateScrollCompositeMinSize();
   }
 
   private void updateRule(HotspotDetailsDto details) {
@@ -311,29 +371,28 @@ public class HotspotsView extends ViewPart {
     if (riskDescriptionContent != null && !riskDescriptionContent.isDisposed()) {
       riskDescriptionContent.dispose();
     }
-    riskDescriptionContent = new RuleDescriptionPanel(tabFolder, languageKey, true);
-    riskDescriptionContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    riskDescriptionContent = new RuleDescriptionPanel(riskDescriptionScrolledContent, languageKey, true);
+    riskDescriptionContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((RuleDescriptionPanel) riskDescriptionContent).updateMonolithicRule(
       new RuleMonolithicDescriptionDto(rule.getRiskDescription()));
-    riskDescriptionTab.setControl(riskDescriptionContent);
 
     if (vulnerabilityDescriptionContent != null && !vulnerabilityDescriptionContent.isDisposed()) {
       vulnerabilityDescriptionContent.dispose();
     }
-    vulnerabilityDescriptionContent = new RuleDescriptionPanel(tabFolder, languageKey, true);
-    vulnerabilityDescriptionContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    vulnerabilityDescriptionContent = new RuleDescriptionPanel(vulnerabilityDescriptionScrolledContent, languageKey, true);
+    vulnerabilityDescriptionContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((RuleDescriptionPanel) vulnerabilityDescriptionContent).updateMonolithicRule(
       new RuleMonolithicDescriptionDto(rule.getVulnerabilityDescription()));
-    vulnerabilityDescriptionTab.setControl(vulnerabilityDescriptionContent);
 
     if (fixRecommendationsContent != null && !fixRecommendationsContent.isDisposed()) {
       fixRecommendationsContent.dispose();
     }
-    fixRecommendationsContent = new RuleDescriptionPanel(tabFolder, languageKey, true);
-    fixRecommendationsContent.setLayoutData(new GridData(SWT.END, SWT.FILL, true, true));
+    fixRecommendationsContent = new RuleDescriptionPanel(fixRecommendationsScrolledContent, languageKey, true);
+    fixRecommendationsContent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     ((RuleDescriptionPanel) fixRecommendationsContent).updateMonolithicRule(
       new RuleMonolithicDescriptionDto(rule.getFixRecommendations()));
-    fixRecommendationsTab.setControl(fixRecommendationsContent);
+
+    updateScrollCompositeMinSize();
   }
 
   public void openHotspot(HotspotDetailsDto hotspot, @Nullable IMarker marker) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
@@ -185,9 +185,9 @@ public class RuleDetailsPanel extends Composite {
     if (ruleDescriptionPanel != null && !ruleDescriptionPanel.isDisposed()) {
       ruleDescriptionPanel.dispose();
     }
-    ruleDescriptionPanel = new RuleDescriptionPanel(scrolledContent, useEditorFontSize);
+    ruleDescriptionPanel = new RuleDescriptionPanel(scrolledContent, languageKey, useEditorFontSize);
     ruleDescriptionPanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-    ruleDescriptionPanel.updateRule(description, languageKey);
+    ruleDescriptionPanel.updateRule(description);
   }
 
   public void displayLoadingIndicator() {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/BrowserUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/BrowserUtils.java
@@ -21,12 +21,18 @@ package org.sonarlint.eclipse.ui.internal.util;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.LocationAdapter;
+import org.eclipse.swt.browser.LocationEvent;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.sonarlint.eclipse.core.SonarLintLogger;
 
-public class BrowserUtils {
+public final class BrowserUtils {
+  private BrowserUtils() {
+    // utility class
+  }
 
   public static void openExternalBrowser(String url) {
     Display.getDefault().asyncExec(() -> {
@@ -38,8 +44,25 @@ public class BrowserUtils {
     });
   }
 
-  private BrowserUtils() {
-    // utility class
-  }
+  public static void addLinkListener(Browser browser) {
+    browser.addLocationListener(new LocationAdapter() {
+      @Override
+      public void changing(LocationEvent event) {
+        var loc = event.location;
 
+        if ("about:blank".equals(loc)) { //$NON-NLS-1$
+          /*
+           * Using the Browser.setText API triggers a location change to "about:blank".
+           * XXX: remove this code once https://bugs.eclipse.org/bugs/show_bug.cgi?id=130314 is fixed
+           */
+          // input set with setText
+          return;
+        }
+
+        event.doit = false;
+
+        openExternalBrowser(loc);
+      }
+    });
+  }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/HTMLUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/HTMLUtils.java
@@ -1,0 +1,116 @@
+package org.sonarlint.eclipse.ui.internal.util;
+
+import java.util.regex.Pattern;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.text.source.SourceViewerConfiguration;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.sonarlint.eclipse.core.internal.extension.SonarLintExtensionTracker;
+import org.sonarlint.eclipse.core.internal.utils.StringUtils;
+
+/** Utility class used for parsing the HTML rule description into native elements */
+public final class HTMLUtils {
+  private static final Pattern preStartingPattern = Pattern.compile("<pre[^>]*>");
+  private static final Pattern preEndingPattern = Pattern.compile("</pre>");
+
+  private HTMLUtils() {
+    // utility class
+  }
+
+  /**
+   *  Parse HTML into native elements and only fallback on {@link SonarLintWebView} for non-parseable elements
+   *  
+   *  @param html to be parsed
+   *  @param parent to add the elements to
+   *  @param languageKey required for code snippet (for syntax highlighting)
+   *  @param useEditorFontSize for SonarLintWebView to use the same font size as other elements
+   */
+  public static void parseIntoElements(String html, Composite parent, String languageKey, boolean useEditorFontSize) {
+    var currentHTML = html;
+    var matcherStart = preStartingPattern.matcher(currentHTML);
+    var matcherEnd = preEndingPattern.matcher(currentHTML);
+
+    while (matcherStart.find() && matcherEnd.find()) {
+      var front = currentHTML.substring(0, matcherStart.start()).trim();
+      if (!front.isEmpty() && !front.isBlank()) {
+        var frontFragment = new SonarLintWebView(parent, useEditorFontSize);
+        var gridData = new GridData();
+        gridData.horizontalAlignment = SWT.FILL;
+        gridData.grabExcessHorizontalSpace = true;
+        frontFragment.setLayoutData(gridData);
+
+        frontFragment.setHtmlBody(front);
+      }
+
+      var middle = currentHTML.substring(matcherStart.end(), matcherEnd.start()).trim();
+      if (!middle.isEmpty() && !middle.isBlank()) {
+        createSourceViewer(StringUtils.xmlDecode(middle), parent, languageKey);
+      }
+
+      currentHTML = currentHTML.substring(matcherEnd.end(), currentHTML.length()).trim();
+      matcherStart = preStartingPattern.matcher(currentHTML);
+      matcherEnd = preEndingPattern.matcher(currentHTML);
+    }
+
+    if (!currentHTML.isEmpty() && !currentHTML.isBlank()) {
+      var endFragment = new SonarLintWebView(parent, useEditorFontSize);
+      var gridData = new GridData();
+      gridData.horizontalAlignment = SWT.FILL;
+      gridData.grabExcessHorizontalSpace = true;
+      endFragment.setLayoutData(gridData);
+
+      endFragment.setHtmlBody(currentHTML);
+    }
+  }
+
+  private static void createSourceViewer(String html, Composite parent, String languageKey) {
+    // Configure the syntax highlighting based on the rule language key and if a configuration and document partitioner
+    // is provided by any plug-in via the extension mechanism.
+    // INFO: Configuration must extend of org.eclipse.jface.text.source.SourceViewerConfiguration
+    // INFO: Document partitioner must implement org.eclipse.jface.text.IDocumentPartitioner
+    var configurationProviders = SonarLintExtensionTracker.getInstance().getSyntaxHighlightingProvider();
+    SourceViewerConfiguration sourceViewerConfigurationNullable = null;
+    for (var configurationProvider : configurationProviders) {
+      var sourceViewerConfigurationOptional = configurationProvider.sourceViewerConfiguration(languageKey);
+      if (sourceViewerConfigurationOptional.isPresent()) {
+        sourceViewerConfigurationNullable = sourceViewerConfigurationOptional.get();
+        break;
+      }
+    }
+
+    IDocumentPartitioner documentPartitionerNullable = null;
+    for (var configurationProvider : configurationProviders) {
+      var documentPartitionerOptional = configurationProvider.documentPartitioner(languageKey);
+      if (documentPartitionerOptional.isPresent()) {
+        documentPartitionerNullable = documentPartitionerOptional.get();
+        break;
+      }
+    }
+
+    var snippetElement = new SourceViewer(parent, null, SWT.BORDER | SWT.H_SCROLL);
+    var gridData = new GridData();
+    gridData.horizontalAlignment = SWT.FILL;
+    gridData.grabExcessHorizontalSpace = true;
+    gridData.horizontalIndent = 10;
+    snippetElement.getTextWidget().setLayoutData(gridData);
+
+    var content = new Document(html);
+    if (sourceViewerConfigurationNullable != null && documentPartitionerNullable != null) {
+      content.setDocumentPartitioner(
+        sourceViewerConfigurationNullable.getConfiguredDocumentPartitioning(snippetElement),
+        documentPartitionerNullable);
+      content.setDocumentPartitioner(documentPartitionerNullable);
+      documentPartitionerNullable.connect(content);
+    }
+
+    if (sourceViewerConfigurationNullable != null) {
+      snippetElement.configure(sourceViewerConfigurationNullable);
+    }
+
+    snippetElement.setDocument(content);
+    snippetElement.setEditable(false);
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/HTMLUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/HTMLUtils.java
@@ -1,3 +1,22 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonarlint.eclipse.ui.internal.util;
 
 import java.util.regex.Pattern;

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SonarLintWebView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SonarLintWebView.java
@@ -33,8 +33,6 @@ import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.browser.Browser;
-import org.eclipse.swt.browser.LocationAdapter;
-import org.eclipse.swt.browser.LocationEvent;
 import org.eclipse.swt.browser.ProgressListener;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
@@ -89,7 +87,7 @@ public class SonarLintWebView extends Composite implements Listener, IPropertyCh
     this.useEditorFontSize = useEditorFontSize;
     try {
       browser = new Browser(this, SWT.NONE);
-      addLinkListener(browser);
+      BrowserUtils.addLinkListener(browser);
       var browserLayoutData = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
       browser.setLayoutData(browserLayoutData);
       browser.setJavascriptEnabled(true);
@@ -212,28 +210,6 @@ public class SonarLintWebView extends Composite implements Listener, IPropertyCh
     return changed;
   }
 
-  private static void addLinkListener(Browser browser) {
-    browser.addLocationListener(new LocationAdapter() {
-      @Override
-      public void changing(LocationEvent event) {
-        var loc = event.location;
-
-        if ("about:blank".equals(loc)) { //$NON-NLS-1$
-          /*
-           * Using the Browser.setText API triggers a location change to "about:blank".
-           * XXX: remove this code once https://bugs.eclipse.org/bugs/show_bug.cgi?id=130314 is fixed
-           */
-          // input set with setText
-          return;
-        }
-
-        event.doit = false;
-
-        BrowserUtils.openExternalBrowser(loc);
-      }
-    });
-  }
-
   private String css() {
     var fontSizePt = defaultFont.getFontData()[0].getHeight();
     return "<style type=\"text/css\">"
@@ -302,21 +278,6 @@ public class SonarLintWebView extends Composite implements Listener, IPropertyCh
   private void reload() {
     browser.setText("<!doctype html><html><head>" + css() + "</head><body>" + htmlBody + "</body></html>");
     browser.requestLayout();
-  }
-
-  public static String escapeHTML(String s) {
-    var out = new StringBuilder(Math.max(16, s.length()));
-    for (var i = 0; i < s.length(); i++) {
-      var c = s.charAt(i);
-      if (c > 127 || c == '"' || c == '<' || c == '>' || c == '&') {
-        out.append("&#");
-        out.append((int) c);
-        out.append(';');
-      } else {
-        out.append(c);
-      }
-    }
-    return out.toString();
   }
 
   private static String hexColor(@Nullable Color color, RGB defaultColor) {


### PR DESCRIPTION
## Summary

Syntax highlighting shall be also available for the security hotspot view even though it does not match with the implementation of the normal rule description panel shown in the "SonarLint Rule Description" and settings menu view.

## Testing

Load `SonarSource/sonarlint-language-server` into the `runtime-EclipseApplication`, connect to **next.sonarqube.com** and open the Security Hotspot (e.g. *java:S2245*).