### PR TITLE
Completly remove slf4j

### DIFF
--- a/org.sonarlint.eclipse.feature/feature.xml
+++ b/org.sonarlint.eclipse.feature/feature.xml
@@ -92,13 +92,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.squareup.okhttp3"
          download-size="0"
          install-size="0"

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -2,10 +2,6 @@
 <?pde version="3.8"?>
 <target name="sonarlint-eclipse-build-commons" sequenceNumber="3">
   <locations>
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.slf4j.api" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
-    </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>


### PR DESCRIPTION
Without this change this will install an additional slf4j-api in eclipse 2023-06 and destroy the eclipse installation (many plugins no longer work).