### PR TITLE
SLE-667: Dialog for muting issues

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
@@ -47,6 +47,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentPar
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedResponse;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 
 
 /**
@@ -86,6 +87,7 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
     try {
       markerType = selectedMarker.getType();
     } catch (CoreException err) {
+      SonarLintLogger.get().error("Error getting marker type", err);
       window.getShell().getDisplay()
       .asyncExec(() -> MessageDialog.openError(window.getShell(), "Mark Issue as Resolved, marker type not available",
         err.getMessage()));

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
@@ -20,6 +20,7 @@
 package org.sonarlint.eclipse.ui.internal.command;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import org.eclipse.core.resources.IMarker;
@@ -30,6 +31,15 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.menus.UIElement;
@@ -40,11 +50,18 @@ import org.sonarlint.eclipse.core.internal.markers.MarkerUtils;
 import org.sonarlint.eclipse.core.internal.utils.JobUtils;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedResponse;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueStatus;
 
+
+/**
+ *  Command invoked on issues matched from SonarQube / SonarCloud to resolve an issue based on server configuration
+ *  and user authentication. Not available on issues only found locally!
+ */
 public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElementUpdater {
-
   @Override
   public void updateElement(UIElement element, Map parameters) {
     var window = element.getServiceLocator().getService(IWorkbenchWindow.class);
@@ -58,6 +75,7 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
     }
   }
 
+  /** Check for issue binding: Either SonarQube or SonarCloud */
   private static Optional<ResolvedBinding> getBinding(IMarker marker) {
     var project = Adapters.adapt(marker.getResource().getProject(), ISonarLintProject.class);
     return SonarLintCorePlugin.getServersManager().resolveBinding(project);
@@ -65,17 +83,18 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
 
   @Override
   protected void execute(IMarker selectedMarker, IWorkbenchWindow window) {
+    var issueKey = selectedMarker.getAttribute(MarkerUtils.SONAR_MARKER_SERVER_ISSUE_KEY_ATTR, null);
+    if (issueKey == null) {
+      // TODO: Show some kind of error!
+      return;
+    }
+    
     var checkJob = new Job("Check user permissions for setting the issue resolution") {
-
       private CheckStatusChangePermittedResponse result;
       private ResolvedBinding resolvedBinding;
 
       @Override
       protected IStatus run(IProgressMonitor monitor) {
-        var issueKey = selectedMarker.getAttribute(MarkerUtils.SONAR_MARKER_SERVER_ISSUE_KEY_ATTR, null);
-        if (issueKey == null) {
-          return Status.error("No issue key for this marker");
-        }
         var binding = getBinding(selectedMarker);
         if (binding.isPresent()) {
           resolvedBinding = binding.get();
@@ -84,9 +103,9 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
               .checkStatusChangePermitted(new CheckStatusChangePermittedParams(resolvedBinding.getProjectBinding().connectionId(), issueKey)));
             return Status.OK_STATUS;
           } catch (InvocationTargetException e) {
-            return new Status(Status.ERROR, SonarLintCorePlugin.PLUGIN_ID, e.getMessage(), e);
+            return new Status(IStatus.ERROR, SonarLintCorePlugin.PLUGIN_ID, e.getMessage(), e);
           } catch (InterruptedException e) {
-            return new Status(Status.CANCEL, SonarLintCorePlugin.PLUGIN_ID, e.getMessage(), e);
+            return new Status(IStatus.CANCEL, SonarLintCorePlugin.PLUGIN_ID, e.getMessage(), e);
           }
 
         } else {
@@ -96,19 +115,123 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
 
     };
 
-    JobUtils.scheduleAfterSuccess(checkJob, () -> afterCheck(checkJob.result, checkJob.resolvedBinding, window));
+    JobUtils.scheduleAfterSuccess(checkJob, () -> afterCheckSuccessful(issueKey, checkJob.result, checkJob.resolvedBinding, window));
 
     checkJob.schedule();
   }
 
-  private static void afterCheck(CheckStatusChangePermittedResponse result, ResolvedBinding resolvedBinding, IWorkbenchWindow window) {
+  private static void afterCheckSuccessful(String issueId, CheckStatusChangePermittedResponse result,
+    ResolvedBinding resolvedBinding, IWorkbenchWindow window) {
     if (!result.isPermitted()) {
       window.getShell().getDisplay()
         .asyncExec(() -> MessageDialog.openError(window.getShell(), "Mark Issue as Resolved on " + (resolvedBinding.getEngineFacade().isSonarCloud() ? "SonarCloud" : "SonarQube"),
           result.getNotPermittedReason()));
       return;
     }
-    window.getShell().getDisplay().asyncExec(() -> MessageDialog.openInformation(window.getShell(), "TODO", "TODO"));
-  }
+    
+    // TODO: Maybe wrap this in a job as well, otherwise at least the IssueService method calls!
+    window.getShell().getDisplay().asyncExec(() -> {
+      var shell = new Shell(window.getShell().getDisplay());
+      shell.setLayout(new GridLayout(2, true));
+      
+      // All possible issue transitions listed below each other
+      final var issueStatusCheckBoxButtons = new ArrayList<IssueStatusCheckBox>();
+      result.getAllowedStatuses().forEach(transition -> {
+        var checkBox = new IssueStatusCheckBox(shell, transition);
 
+        checkBox.getCheckBox().setText(transition.getTitle() + ": " + transition.getDescription());
+        var gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+        gridData.horizontalSpan = 2;
+        checkBox.getCheckBox().setLayoutData(gridData);
+        
+        checkBox.getCheckBox().addSelectionListener(new SelectionAdapter() {
+          @Override
+          public void widgetSelected(SelectionEvent e) {
+            issueStatusCheckBoxButtons.stream()
+              .filter(it -> it.getCheckBox() != checkBox.getCheckBox())
+              .forEach(it -> it.getCheckBox().setSelection(false));
+            
+            // TODO: Enable "Resolve issue" button
+          }
+        });
+        
+        issueStatusCheckBoxButtons.add(checkBox);
+      });
+      
+      // Optional comment for the issue
+      final var commentSection = new Text(shell, SWT.MULTI);
+      var gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+      gridData.horizontalSpan = 2;
+      commentSection.setLayoutData(gridData);
+      
+      // Button to just cancel resolving the issue
+      final var cancelButton = new Button(shell, SWT.NONE);
+      cancelButton.setText("Cancel");
+      cancelButton.addSelectionListener(new SelectionAdapter() {
+        @Override
+        public void widgetSelected(SelectionEvent e) {
+          shell.close();
+        }
+      });
+      
+      // Button to finish resolving the issue
+      final var resolveButton = new Button(shell, SWT.NONE);
+      resolveButton.setText("Resolve issue");
+      resolveButton.setEnabled(false);
+      resolveButton.addSelectionListener(new SelectionAdapter() {
+        @Override
+        public void widgetSelected(SelectionEvent e) {
+          // get the selected checkbox
+          var selectedButton = issueStatusCheckBoxButtons.stream()
+            .filter(it -> it.getCheckBox().getSelection())
+            .findFirst()
+            .get();
+          
+          // update the status on SQ / SC
+          var issueService = SonarLintBackendService.get().getBackend().getIssueService();
+          issueService.changeStatus(new ChangeIssueStatusParams(resolvedBinding.getEngineFacade().getId(),
+            issueId,
+            selectedButton.getIssueStatus(),
+            /* TODO */ false));
+          
+          // check if text box contains text
+          var comment = commentSection.getText();
+          if (!comment.isBlank()) {
+            issueService.addComment(new AddIssueCommentParams(resolvedBinding.getEngineFacade().getId(),
+              issueId,
+              comment));
+          }
+          
+          shell.close();
+          // jump to the post-resolve steps like updating the IDE view
+          afterResolving();
+        }
+      });
+      
+      shell.open();
+    });
+  }
+  
+  private static void afterResolving() {
+    //
+  }
+  
+  /** Utility class to wrap a SWT Button (CheckBox) with its corresponding IssueStatus */
+  static class IssueStatusCheckBox {
+    private final Button checkBox;
+    private final IssueStatus issueStatus;
+    
+    public IssueStatusCheckBox(Composite parent, IssueStatus issueStatus) {
+      this.issueStatus = issueStatus;
+      this.checkBox = new Button(parent, SWT.CHECK);
+    }
+    
+    public Button getCheckBox() {
+      return checkBox;
+    }
+    
+    public IssueStatus getIssueStatus() {
+      return issueStatus;
+    }
+  }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/MarkAsResolvedCommand.java
@@ -135,7 +135,6 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
       return;
     }
     
-    // run the
     window.getShell().getDisplay().asyncExec(() -> {
       var dialog = new MarkAsResolvedDialog(window.getShell(), result.getAllowedStatuses(), hostURL, isSonarCloud);
       if (dialog.open() == Window.OK) {
@@ -146,7 +145,7 @@ public class MarkAsResolvedCommand extends AbstractIssueCommand implements IElem
         issueService.changeStatus(new ChangeIssueStatusParams(resolvedBinding.getEngineFacade().getId(),
           markerId,
           newStatus,
-          markerType == SonarLintCorePlugin.MARKER_TAINT_ID));
+          markerType.equals(SonarLintCorePlugin.MARKER_TAINT_ID)));
         
         // (optional) issue status comment
         var comment = dialog.getFinalComment();

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
@@ -41,17 +41,20 @@ import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueStatus;
 
 /** Dialog for marking an issue as resolved using the possible transitions */
 public class MarkAsResolvedDialog extends Dialog {
-  final ArrayList<IssueStatusCheckBox> issueStatusCheckBoxButtons = new ArrayList<>();
+  private final ArrayList<IssueStatusCheckBox> issueStatusCheckBoxButtons = new ArrayList<>();
   private Text commentSection;
   private List<IssueStatus> transitions;
+  private String formattingHelpURL;
   
   private IssueStatus finalTransition;
   @Nullable
   private String finalComment;
 
-  public MarkAsResolvedDialog(Shell parentShell, List<IssueStatus> transitions) {
+  public MarkAsResolvedDialog(Shell parentShell, List<IssueStatus> transitions, String hostURL, boolean isSonarCloud) {
     super(parentShell);
     this.transitions = transitions;
+    
+    this.formattingHelpURL = hostURL + (isSonarCloud ? "/markdown/help" : "/formatting/help");
   }
   
   @Override
@@ -101,8 +104,7 @@ public class MarkAsResolvedDialog extends Dialog {
     gridData.grabExcessHorizontalSpace = true;
     gridData.horizontalSpan = 2;
     commentHelp.setLayoutData(gridData);
-    // TODO: Where to get this link from?
-    commentHelp.setText("<a href=\"https://next.sonarqube.com\">Formatting Help</a>: *Bold* `Code` * Bulleted point");
+    commentHelp.setText("<a href=\"" + formattingHelpURL + "\">Formatting Help</a>: *Bold* `Code` * Bulleted point");
     
     return container;
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
@@ -25,6 +25,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -36,6 +38,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueStatus;
 
 /** Dialog for marking an issue as resolved using the possible transitions */
@@ -58,13 +61,11 @@ public class MarkAsResolvedDialog extends Dialog {
   @Override
   protected Control createDialogArea(Composite parent) {
     var container = (Composite) super.createDialogArea(parent);
-    container.setLayout(new GridLayout(2, true));
     
     var group = new Group(container, SWT.NONE);
     group.setLayout(new GridLayout(1, true));
     var gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
     gridData.grabExcessHorizontalSpace = true;
-    gridData.horizontalSpan = 2;
     group.setLayoutData(gridData);
     
     transitions.forEach(transition -> {
@@ -80,24 +81,24 @@ public class MarkAsResolvedDialog extends Dialog {
     issueStatusRadioButtons.get(0).getButton().setSelection(true);
     
     var commentTitle = new Label(container, SWT.NONE);
-    gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
-    gridData.grabExcessHorizontalSpace = true;
-    gridData.horizontalSpan = 2;
+    gridData = new GridData(SWT.FILL, SWT.FILL, true, false);
     commentTitle.setLayoutData(gridData);
     commentTitle.setText("Add a comment (optional)");
     
     commentSection = new Text(container, SWT.MULTI | SWT.BORDER | SWT.WRAP | SWT.V_SCROLL);
-    gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
-    gridData.grabExcessHorizontalSpace = true;
-    gridData.horizontalSpan = 2;
+    gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
     commentSection.setLayoutData(gridData);
     
     var commentHelp = new Link(container, SWT.NONE);
-    gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
-    gridData.grabExcessHorizontalSpace = true;
-    gridData.horizontalSpan = 2;
+    gridData = new GridData(SWT.FILL, SWT.FILL, true, false);
     commentHelp.setLayoutData(gridData);
     commentHelp.setText("<a href=\"" + formattingHelpURL + "\">Formatting Help</a>: *Bold* `Code` * Bulleted point");
+    commentHelp.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        BrowserUtils.openExternalBrowser(formattingHelpURL, MarkAsResolvedDialog.this.getShell().getDisplay());
+      }
+    });
     
     return container;
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
@@ -1,0 +1,161 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.dialog;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueStatus;
+
+/** Dialog for marking an issue as resolved using the possible transitions */
+public class MarkAsResolvedDialog extends Dialog {
+  final ArrayList<IssueStatusCheckBox> issueStatusCheckBoxButtons = new ArrayList<>();
+  private Text commentSection;
+  private List<IssueStatus> transitions;
+  
+  private IssueStatus finalTransition;
+  @Nullable
+  private String finalComment;
+
+  public MarkAsResolvedDialog(Shell parentShell, List<IssueStatus> transitions) {
+    super(parentShell);
+    this.transitions = transitions;
+  }
+  
+  @Override
+  protected Control createDialogArea(Composite parent) {
+    var container = (Composite) super.createDialogArea(parent);
+    container.setLayout(new GridLayout(2, true));
+    
+    transitions.forEach(transition -> {
+      var checkBox = new IssueStatusCheckBox(container, transition);
+
+      checkBox.getCheckBox().setText(transition.getTitle() + "\n" + transition.getDescription());
+      var gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+      gridData.grabExcessHorizontalSpace = true;
+      gridData.horizontalSpan = 2;
+      checkBox.getCheckBox().setLayoutData(gridData);
+      
+      // listener prohibiting de-selecting check boxes and multi-selection
+      checkBox.getCheckBox().addSelectionListener(new SelectionAdapter() {
+        @Override
+        public void widgetSelected(SelectionEvent e) {
+          checkBox.getCheckBox().setSelection(true);
+          issueStatusCheckBoxButtons.stream()
+            .filter(it -> it.getCheckBox() != checkBox.getCheckBox())
+            .forEach(it -> it.getCheckBox().setSelection(false));
+        }
+      });
+      
+      issueStatusCheckBoxButtons.add(checkBox);
+    });
+    issueStatusCheckBoxButtons.get(0).getCheckBox().setSelection(true);
+    
+    var commentTitle = new Label(container, SWT.NONE);
+    var gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+    gridData.grabExcessHorizontalSpace = true;
+    gridData.horizontalSpan = 2;
+    commentTitle.setLayoutData(gridData);
+    commentTitle.setText("\nAdd a comment (optional)");
+    
+    commentSection = new Text(container, SWT.MULTI | SWT.BORDER | SWT.WRAP | SWT.V_SCROLL);
+    gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+    gridData.grabExcessHorizontalSpace = true;
+    gridData.horizontalSpan = 2;
+    commentSection.setLayoutData(gridData);
+    
+    var commentHelp = new Link(container, SWT.NONE);
+    gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+    gridData.grabExcessHorizontalSpace = true;
+    gridData.horizontalSpan = 2;
+    commentHelp.setLayoutData(gridData);
+    // TODO: Where to get this link from?
+    commentHelp.setText("<a href=\"https://next.sonarqube.com\">Formatting Help</a>: *Bold* `Code` * Bulleted point");
+    
+    return container;
+  }
+  
+  @Override
+  protected void createButtonsForButtonBar(Composite parent) {
+    createButton(parent, IDialogConstants.OK_ID, "Mark as resolved", true);
+    createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+  }
+  
+  @Override
+  protected Point getInitialSize() {
+    return new Point(600, 300);
+  }
+  
+  @Override
+  protected void okPressed() {
+    // INFO: At every point in time there is exactly one check box selected!
+    this.finalTransition = issueStatusCheckBoxButtons.stream()
+      .filter(it -> it.getCheckBox().getSelection())
+      .findFirst()
+      .get().getIssueStatus();
+    this.finalComment = commentSection.getText();
+    
+    super.okPressed();
+  }
+  
+  /** After finishing the dialog we can use this for invoking SQ / SC API */
+  public IssueStatus getFinalTransition() {
+    return this.finalTransition;
+  }
+  
+  /** After finishing the dialog we can use this for invoking SQ / SC API */
+  public String getFinalComment() {
+    return this.finalComment;
+  }
+  
+  /** Utility class to wrap a SWT Button (CheckBox) with its corresponding IssueStatus */
+  static class IssueStatusCheckBox {
+    private final Button checkBox;
+    private final IssueStatus issueStatus;
+    
+    public IssueStatusCheckBox(Composite parent, IssueStatus issueStatus) {
+      this.issueStatus = issueStatus;
+      this.checkBox = new Button(parent, SWT.CHECK | SWT.BORDER);
+    }
+    
+    public Button getCheckBox() {
+      return checkBox;
+    }
+    
+    public IssueStatus getIssueStatus() {
+      return issueStatus;
+    }
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/package-info.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.dialog;


### PR DESCRIPTION
## Summary
This adds a dialog for the muting issues action based on the IntelliJ implementation. Allowed issue transitions are added dynamically based on the permissions check prior.

Also the `CompletableFuture` instances from the `IssueService` method invocations are currently not functional as I did not want to change anything by mistake, I'm mostly testing with SLLS.

## Testing
Not yet tested but in the end when everything is ready we should add integration tests both for muting an issue and a taint vulnerability!