### PR TITLE
SLE-626: Node.js on macOS

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/AbstractSonarLintTest.java
+++ b/its/src/org/sonarlint/eclipse/its/AbstractSonarLintTest.java
@@ -60,12 +60,14 @@ import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.osgi.framework.Version;
 import org.osgi.service.prefs.BackingStoreException;
+import org.sonarlint.eclipse.its.reddeer.preferences.FileAssociationsPreferences;
 import org.sonarlint.eclipse.its.reddeer.preferences.RuleConfigurationPreferences;
 import org.sonarlint.eclipse.its.reddeer.views.SonarLintConsole;
 import org.sonarlint.eclipse.its.reddeer.views.SonarLintConsole.ShowConsoleOption;
@@ -109,6 +111,8 @@ public abstract class AbstractSonarLintTest {
     new WorkbenchShell().maximize();
     new CleanWorkspaceRequirement().fulfill();
 
+    // File associations must be set explicitly on macOS!
+    restoreDefaultFileAssociationConfiguration();
     restoreDefaultRulesConfiguration();
 
     ConfigurationScope.INSTANCE.getNode(UI_PLUGIN_ID).remove(PREF_SECRETS_EVER_DETECTED);
@@ -133,6 +137,12 @@ public abstract class AbstractSonarLintTest {
   private static final List<String> sonarlintJobFamilies = List.of(
     "org.sonarlint.eclipse.projectJob",
     "org.sonarlint.eclipse.projectsJob");
+  
+  @Before
+  public final void before() {
+    // File associations must be set explicitly on macOS!
+    setSpecificFileAssociationConfiguration();
+  }
 
   @BeforeClass
   public static final void beforeClass() throws BackingStoreException {
@@ -273,6 +283,18 @@ public abstract class AbstractSonarLintTest {
       .url(server.getUrl())
       .credentials(Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD)
       .build());
+  }
+  
+  static void setSpecificFileAssociationConfiguration() {
+    var preferencePage = FileAssociationsPreferences.open();
+    preferencePage.enforceFileAssociation();
+    preferencePage.ok();
+  }
+
+  void restoreDefaultFileAssociationConfiguration() {
+    var preferencePage = FileAssociationsPreferences.open();
+    preferencePage.resetFileAssociation();
+    preferencePage.ok();
   }
 
   void restoreDefaultRulesConfiguration() {

--- a/its/src/org/sonarlint/eclipse/its/reddeer/preferences/FileAssociationsPreferences.java
+++ b/its/src/org/sonarlint/eclipse/its/reddeer/preferences/FileAssociationsPreferences.java
@@ -1,0 +1,57 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.reddeer.preferences;
+
+import org.eclipse.reddeer.core.matcher.WithLabelMatcher;
+import org.eclipse.reddeer.core.reference.ReferencedComposite;
+import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyPage;
+import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
+import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+
+public class FileAssociationsPreferences extends PropertyPage {
+  private static final String LABEL = "Open unassociated files with:";
+
+  public FileAssociationsPreferences(ReferencedComposite referencedComposite) {
+    super(referencedComposite, "General", "Editors", "File Associations");
+  }
+
+  public static FileAssociationsPreferences open() {
+    var preferenceDialog = new WorkbenchPreferenceDialog();
+    if (!preferenceDialog.isOpen()) {
+      preferenceDialog.open();
+    }
+
+    var preferences = new FileAssociationsPreferences(preferenceDialog);
+    preferenceDialog.select(preferences);
+    return preferences;
+  }
+
+  public void resetFileAssociation() {
+    new DefaultCombo(this, new WithLabelMatcher(LABEL)).setSelection("System Editor; if none: Text Editor");
+  }
+
+  public void enforceFileAssociation() {
+    new DefaultCombo(this, new WithLabelMatcher(LABEL)).setSelection("Text Editor");
+  }
+
+  public void ok() {
+    ((WorkbenchPreferenceDialog) referencedComposite).ok();
+  }
+}

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -17,7 +17,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
 				  <artifactId>sonarlint-core-osgi</artifactId>
-				  <version>9.0.0.74161</version>
+				  <version>9.0.0.74196</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
## Summary
Automatic detection of Node.js on macOS does not work when added to $PATH from the user shell configuration.

## Testing
Additional changes to ITs finally make the tests run on macOS. This issue of file associations was fixed with this commit.
