### PR TITLE
SLE-678: await when accessing markers

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/FileExclusionsTest.java
+++ b/its/src/org/sonarlint/eclipse/its/FileExclusionsTest.java
@@ -37,9 +37,9 @@ import org.sonarlint.eclipse.its.reddeer.views.SonarLintIssueMarker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 public class FileExclusionsTest extends AbstractSonarLintTest {
-
   @Test
   public void should_exclude_file() throws Exception {
     new JavaPerspective().open();
@@ -53,8 +53,8 @@ public class FileExclusionsTest extends AbstractSonarLintTest {
 
     var sonarlintIssues = issuesView.getIssues();
 
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription)
-      .containsOnly(tuple("Hello.java", "Replace this use of System.out or System.err by a logger."));
+    await().untilAsserted(() -> assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription)
+      .containsOnly(tuple("Hello.java", "Replace this use of System.out or System.err by a logger.")));
 
     new JavaEditor("Hello.java").close();
 
@@ -105,5 +105,4 @@ public class FileExclusionsTest extends AbstractSonarLintTest {
 
     preferenceDialog.cancel();
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/LocalLeakTest.java
+++ b/its/src/org/sonarlint/eclipse/its/LocalLeakTest.java
@@ -28,9 +28,9 @@ import org.sonarlint.eclipse.its.reddeer.views.SonarLintIssueMarker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 public class LocalLeakTest extends AbstractSonarLintTest {
-
   @Test
   public void shouldComputeLocalLeak() {
     new JavaPerspective().open();
@@ -48,19 +48,18 @@ public class LocalLeakTest extends AbstractSonarLintTest {
 
     var sonarlintIssues = issuesView.getIssues();
 
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
-      .containsOnly(tuple("Hello.java", "Replace this use of System.out or System.err by a logger.", ""));
+    await().untilAsserted(() -> assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+      .containsOnly(tuple("Hello.java", "Replace this use of System.out or System.err by a logger.", "")));
 
     // Change content
     var javaEditor = new JavaEditor("Hello.java");
     javaEditor.insertText(7, 43, "\nSystem.out.println(\"Hello1\");");
     doAndWaitForSonarLintAnalysisJob(() -> javaEditor.save());
 
-    sonarlintIssues = issuesView.getIssues();
-
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+    var sonarlintIssues2 = issuesView.getIssues();
+    await().untilAsserted(() -> assertThat(sonarlintIssues2).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
       .containsOnly(tuple("Hello.java", "Replace this use of System.out or System.err by a logger.", ""),
-        tuple("Hello.java", "Replace this use of System.out or System.err by a logger.", "few seconds ago"));
+        tuple("Hello.java", "Replace this use of System.out or System.err by a logger.", "few seconds ago")));
   }
 
   @Test
@@ -77,19 +76,18 @@ public class LocalLeakTest extends AbstractSonarLintTest {
 
     var sonarlintIssues = issuesView.getIssues();
 
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
-      .containsOnly(tuple("hello.js", "Multiline support is limited to browsers supporting ES5 only.", ""));
+    await().untilAsserted(() -> assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+      .containsOnly(tuple("hello.js", "Multiline support is limited to browsers supporting ES5 only.", "")));
 
     // Change content
     var textEditor = new TextEditor("hello.js");
     textEditor.insertText(2, 17, "\nlet i;");
     doAndWaitForSonarLintAnalysisJob(() -> textEditor.save());
 
-    sonarlintIssues = issuesView.getIssues();
-
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+    var sonarlintIssues2 = issuesView.getIssues();
+    await().untilAsserted(() -> assertThat(sonarlintIssues2).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
       .containsOnly(tuple("hello.js", "Multiline support is limited to browsers supporting ES5 only.", ""),
-        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago"));
+        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago")));
 
     // Insert content that should crash analyzer
     var beforeCrash = textEditor.getText();
@@ -97,22 +95,19 @@ public class LocalLeakTest extends AbstractSonarLintTest {
     doAndWaitForSonarLintAnalysisJob(() -> textEditor.save());
 
     // Issues are still there
-    sonarlintIssues = issuesView.getIssues();
-
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+    var sonarlintIssues3 = issuesView.getIssues();
+    await().untilAsserted(() -> assertThat(sonarlintIssues3).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
       .containsOnly(tuple("hello.js", "Multiline support is limited to browsers supporting ES5 only.", ""),
-        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago"));
+        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago")));
 
     // Fix parsing issue
     textEditor.setText(beforeCrash);
     doAndWaitForSonarLintAnalysisJob(() -> textEditor.save());
 
-    sonarlintIssues = issuesView.getIssues();
-
-    assertThat(sonarlintIssues).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
+    var sonarlintIssues4 = issuesView.getIssues();
+    await().untilAsserted(() -> assertThat(sonarlintIssues4).extracting(SonarLintIssueMarker::getResource, SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getCreationDate)
       .containsOnly(tuple("hello.js", "Multiline support is limited to browsers supporting ES5 only.", ""),
-        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago"));
+        tuple("hello.js", "Remove the declaration of the unused 'i' variable.", "few seconds ago")));
 
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/MavenTest.java
+++ b/its/src/org/sonarlint/eclipse/its/MavenTest.java
@@ -29,9 +29,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 public class MavenTest extends AbstractSonarLintTest {
-
   @Test
   public void shouldNotAnalyzeResourcesInNestedModules() {
     new JavaPerspective().open();
@@ -50,25 +50,24 @@ public class MavenTest extends AbstractSonarLintTest {
     rootProject.getResource("sample-module1", "src", "main", "java", "hello", "Hello1.java").open();
     assertThat(scheduledAnalysisJobCount.get()).isEqualTo(previousAnalysisJobCount);
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers()).isEmpty();
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers()).isEmpty());
     defaultEditor.close();
 
     openFileAndWaitForAnalysisCompletion(sampleModule1Project.getResource("src/main/java", "hello", "Hello1.java"));
-    defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    var defaultEditor2 = new DefaultEditor();
+    await().untilAsserted(() -> assertThat(defaultEditor2.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
-      .containsExactly(tuple("Replace this use of System.out or System.err by a logger.", 9));
+      .containsExactly(tuple("Replace this use of System.out or System.err by a logger.", 9)));
     defaultEditor.close();
 
     if (!platformVersion().toString().startsWith("4.4") && !platformVersion().toString().startsWith("4.5")) {
       // Issues on pom.xml
       openFileAndWaitForAnalysisCompletion(rootProject.getResource("pom.xml"));
-      defaultEditor = new DefaultEditor();
-      assertThat(defaultEditor.getMarkers())
+      var defaultEditor3 = new DefaultEditor();
+      await().untilAsserted(() -> assertThat(defaultEditor3.getMarkers())
         .extracting(Marker::getText, Marker::getLineNumber)
-        .containsExactly(tuple("Replace \"pom.name\" with \"project.name\".", 11));
+        .containsExactly(tuple("Replace \"pom.name\" with \"project.name\".", 11)));
       defaultEditor.close();
     }
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/RuleDescriptionViewTest.java
+++ b/its/src/org/sonarlint/eclipse/its/RuleDescriptionViewTest.java
@@ -36,7 +36,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
 public class RuleDescriptionViewTest extends AbstractSonarLintTest {
-
   @Test
   public void openRuleDescription() {
     new JavaPerspective().open();
@@ -50,9 +49,9 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(project.getResource("src", "hello", "Hello.java"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
-      .containsExactly(tuple("Replace this use of System.out or System.err by a logger.", 9));
+      .containsExactly(tuple("Replace this use of System.out or System.err by a logger.", 9)));
 
     onTheFlyView.selectItem(0);
     ruleDescriptionView.open();
@@ -80,10 +79,10 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(project.getResource("src", "hello", "MonsterClass.java"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
       .contains(
-        tuple("Split this “Monster Class” into smaller and more specialized ones to reduce its dependencies on other classes from 3 to the maximum authorized 2 or less.", 3));
+        tuple("Split this “Monster Class” into smaller and more specialized ones to reduce its dependencies on other classes from 3 to the maximum authorized 2 or less.", 3)));
 
     onTheFlyView.getIssues(new MarkerDescriptionMatcher(CoreMatchers.containsString("Monster Class"))).get(0).select();
     ruleDescriptionView.open();
@@ -93,5 +92,4 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
 
     assertThat(ruleDescriptionView.getSections().getTabItemLabels()).containsExactly("Why is this an issue?", "How can I fix it?", "More Info");
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/RulesConfigurationTest.java
+++ b/its/src/org/sonarlint/eclipse/its/RulesConfigurationTest.java
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
 public class RulesConfigurationTest extends AbstractSonarLintTest {
-
   @Test
   public void deactivate_rule() {
     new JavaPerspective().open();
@@ -158,5 +157,4 @@ public class RulesConfigurationTest extends AbstractSonarLintTest {
         tuple("Replace this use of System.out or System.err by a logger.", 9),
         tuple("Refactor this method to reduce its Cognitive Complexity from 24 to the 15 allowed.", 12)));
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/SecondaryLocationsTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SecondaryLocationsTest.java
@@ -29,9 +29,9 @@ import org.sonarlint.eclipse.its.reddeer.views.OnTheFlyView;
 import org.sonarlint.eclipse.its.reddeer.views.SonarLintIssueMarker;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class SecondaryLocationsTest extends AbstractSonarLintTest {
-
   private static OnTheFlyView onTheFlyView;
   private static IssueLocationsView locationsView;
   private static Project rootProject;
@@ -51,9 +51,9 @@ public class SecondaryLocationsTest extends AbstractSonarLintTest {
     openAndAnalyzeFile("SimpleIssue.java");
 
     var issueTitle = "Complete the task associated to this TODO comment.";
-    assertThat(onTheFlyView.getIssues())
+    await().untilAsserted(() -> assertThat(onTheFlyView.getIssues())
       .extracting(SonarLintIssueMarker::getDescription)
-      .containsOnly(issueTitle);
+      .containsOnly(issueTitle));
     onTheFlyView.selectItem(0);
 
     var flowItems = locationsView.getTree().getItems();
@@ -70,9 +70,9 @@ public class SecondaryLocationsTest extends AbstractSonarLintTest {
     var helloEditor = openAndAnalyzeFile("SingleFlow.java");
 
     var issueTitle = "\"NullPointerException\" will be thrown when invoking method \"doAnotherThingWith()\".";
-    assertThat(onTheFlyView.getIssues())
+    await().untilAsserted(() -> assertThat(onTheFlyView.getIssues())
       .extracting(SonarLintIssueMarker::getDescription)
-      .containsOnly(issueTitle + " [+5 locations]");
+      .containsOnly(issueTitle + " [+5 locations]"));
     onTheFlyView.selectItem(0);
 
     var flowItems = locationsView.getTree().getItems();
@@ -92,9 +92,9 @@ public class SecondaryLocationsTest extends AbstractSonarLintTest {
     openAndAnalyzeFile("HighlightOnly.java");
 
     var issueTitle = "Remove these useless parentheses.";
-    assertThat(onTheFlyView.getIssues())
+    await().untilAsserted(() -> assertThat(onTheFlyView.getIssues())
       .extracting(SonarLintIssueMarker::getDescription)
-      .containsOnly(issueTitle + " [+1 location]");
+      .containsOnly(issueTitle + " [+1 location]"));
     onTheFlyView.selectItem(0);
 
     var allItems = locationsView.getTree().getItems();
@@ -110,9 +110,9 @@ public class SecondaryLocationsTest extends AbstractSonarLintTest {
     var helloEditor = openAndAnalyzeFile("MultiFlows.java");
 
     var issueTitle = "\"NullPointerException\" will be thrown when invoking method \"doAnotherThingWith()\".";
-    assertThat(onTheFlyView.getIssues())
+    await().untilAsserted(() -> assertThat(onTheFlyView.getIssues())
       .extracting(SonarLintIssueMarker::getDescription)
-      .containsOnly(issueTitle + " [+2 flows]");
+      .containsOnly(issueTitle + " [+2 flows]"));
     onTheFlyView.selectItem(0);
 
     var allItems = locationsView.getTree().getItems();
@@ -146,9 +146,9 @@ public class SecondaryLocationsTest extends AbstractSonarLintTest {
     var cognitiveComplexityEditor = openAndAnalyzeFile("CognitiveComplexity.java");
 
     var issueTitle = "Refactor this method to reduce its Cognitive Complexity from 24 to the 15 allowed.";
-    assertThat(onTheFlyView.getIssues())
+    await().untilAsserted(() -> assertThat(onTheFlyView.getIssues())
       .extracting(SonarLintIssueMarker::getDescription)
-      .containsOnly(issueTitle + " [+15 locations]");
+      .containsOnly(issueTitle + " [+15 locations]"));
     onTheFlyView.selectItem(0);
 
     var allItems = locationsView.getTree().getItems();

--- a/its/src/org/sonarlint/eclipse/its/SecretsTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SecretsTest.java
@@ -32,9 +32,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 public class SecretsTest extends AbstractSonarLintTest {
-
   @Test
   public void shouldFindSecretsInTextFiles() {
     new JavaPerspective().open();
@@ -43,10 +43,10 @@ public class SecretsTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("secret"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
       .containsOnly(
-        tuple("Make sure this AWS Secret Access Key is not disclosed.", 3));
+        tuple("Make sure this AWS Secret Access Key is not disclosed.", 3)));
 
     var notificationShell = new DefaultShell("SonarLint - Secret(s) detected");
     new DefaultLink(notificationShell, "Dismiss").click();
@@ -60,10 +60,10 @@ public class SecretsTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("src", "sec", "Secret.java"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
       .containsOnly(
-        tuple("Make sure this AWS Secret Access Key is not disclosed.", 4));
+        tuple("Make sure this AWS Secret Access Key is not disclosed.", 4)));
 
     var notificationShell = new DefaultShell("SonarLint - Secret(s) detected");
     new DefaultLink(notificationShell, "Dismiss").click();
@@ -83,9 +83,8 @@ public class SecretsTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("secret.txt"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
-      .isEmpty();
+      .isEmpty());
   }
-
 }

--- a/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
@@ -64,11 +64,11 @@ import org.sonarqube.ws.client.setting.SetRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SonarQubeConnectedModeTest extends AbstractSonarLintTest {
-
   @ClassRule
   public static OrchestratorRule orchestrator;
 
@@ -228,10 +228,10 @@ public class SonarQubeConnectedModeTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("src", "sec", "Secret.java"));
 
     var defaultEditor = new DefaultEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
       .containsOnly(
-        tuple("Make sure this AWS Secret Access Key is not disclosed.", 4));
+        tuple("Make sure this AWS Secret Access Key is not disclosed.", 4)));
 
     var notificationShell = new DefaultShell("SonarLint - Secret(s) detected");
     new DefaultLink(notificationShell, "Dismiss").click();
@@ -250,10 +250,10 @@ public class SonarQubeConnectedModeTest extends AbstractSonarLintTest {
     openFileAndWaitForAnalysisCompletion(file);
 
     var defaultEditor = new TextEditor();
-    assertThat(defaultEditor.getMarkers())
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers())
       .extracting(Marker::getText, Marker::getLineNumber)
       .containsOnly(
-        tuple("Replace this use of System.out or System.err by a logger.", 9));
+        tuple("Replace this use of System.out or System.err by a logger.", 9)));
 
     var qualityProfile = getQualityProfile(JAVA_SIMPLE_PROJECT_KEY, "SonarLint IT Java");
     deactivateRule(qualityProfile, "S106");
@@ -264,7 +264,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarLintTest {
       defaultEditor.save();
     });
 
-    assertThat(defaultEditor.getMarkers()).isEmpty();
+    await().untilAsserted(() -> assertThat(defaultEditor.getMarkers()).isEmpty());
   }
 
   private static void createConnectionAndBindProject(String projectKey) {
@@ -347,5 +347,4 @@ public class SonarQubeConnectedModeTest extends AbstractSonarLintTest {
     // Starting from SonarJava 6.0 (embedded in SQ 8.2), rule repository has been changed
     return orchestrator.getServer().version().isGreaterThanOrEquals(8, 2) ? ("java:" + key) : ("squid:" + key);
   }
-
 }


### PR DESCRIPTION
Using `await().unitlAsserted(...)` for tests checking for issue markers that are dependent on an analysis.