### PR TITLE
SLE-616: Update binding view based on project

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/BindingsView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/BindingsView.java
@@ -271,7 +271,7 @@ public class BindingsView extends CommonNavigator {
       } else if (event.getDelta() != null) {
         try {
           event.getDelta().accept((IResourceDelta delta) -> {
-            if (delta.getKind() == IResourceDelta.CHANGED) {
+            if (delta.getKind() == IResourceDelta.CHANGED && (delta.getResource().getType() & IResource.ROOT) != 0) {
               // INFO: With adding "IResourceDelta.ADDED" to the mask we can also update the binding view when
               //       importing a project. Therefore the user can see if a newly imported project is already
               //       correctly binded.


### PR DESCRIPTION
When a project is closed (or reopened) or deleted, the SonarLint Bindings view should be updated to not include irrelevant projects which might lead to errors when trying to change the binding of it. This does not include importing a project.