### PR TITLE
Fix RadioButton label

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/MarkAsResolvedDialog.java
@@ -71,7 +71,7 @@ public class MarkAsResolvedDialog extends Dialog {
 
     transitions.forEach(transition -> {
       var btn = new IssueStatusRadioButton(group, transition);
-      btn.getButton().setText(transition.getTitle() + "\n" + transition.getDescription());
+      btn.getButton().setText(transition.getTitle() + " - " + transition.getDescription());
 
       var innerGridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
       innerGridData.grabExcessHorizontalSpace = true;


### PR DESCRIPTION
The label uses the OS native element and cannot show line breaks on Windows (not even Windows-specific line breaks).