### PR TITLE
SLE-694: Remove deprecated methods

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPartTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPartTest.java
@@ -22,7 +22,7 @@ package org.sonarlint.eclipse.ui.internal.properties;
 import java.util.List;
 import org.junit.Test;
 import org.sonarlint.eclipse.core.internal.preferences.RuleConfig;
-import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.RuleDefinitionDto;
 import org.sonarsource.sonarlint.core.commons.Language;
 import org.sonarsource.sonarlint.core.commons.RuleKey;
 
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RulesConfigurationPartTest {
-
   private static final RuleKey ACTIVE = mockRuleKey("ACTIVE");
   private static final RuleKey ACTIVE_EXCLUDED = mockRuleKey("ACTIVE_EXCLUDED");
   private static final RuleKey INACTIVE = mockRuleKey("INACTIVE");
@@ -52,9 +51,9 @@ public class RulesConfigurationPartTest {
   private static RuleKey mockRuleKey(String key) {
     return new RuleKey("squid", key);
   }
-
-  private StandaloneRuleDetails mockRuleDetails(RuleKey ruleKey, boolean activeByDefault) {
-    var ruleDetails = mock(StandaloneRuleDetails.class);
+  
+  private RuleDefinitionDto mockRuleDetails(RuleKey ruleKey, boolean activeByDefault) {
+    var ruleDetails = mock(RuleDefinitionDto.class);
     when(ruleDetails.getKey()).thenReturn(ruleKey.toString());
     when(ruleDetails.isActiveByDefault()).thenReturn(activeByDefault);
     when(ruleDetails.getLanguage()).thenReturn(Language.JAVA);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -54,6 +54,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDe
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetEffectiveRuleDetailsResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.GetStandaloneRuleDescriptionResponse;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.ListAllStandaloneRulesDefinitionsResponse;
 import org.sonarsource.sonarlint.core.commons.Language;
 
 import static java.util.Objects.requireNonNull;
@@ -157,6 +158,11 @@ public class SonarLintBackendService {
       ideName = defaultString(product.getName(), "Eclipse");
     }
     return ideName;
+  }
+  
+  /** Get all the rules available in standalone mode */
+  public CompletableFuture<ListAllStandaloneRulesDefinitionsResponse> getStandaloneRules() {
+    return getBackend().getRulesService().listAllStandaloneRulesDefinitions();
   }
 
   /** Get the rules details (global configuration) */

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/StandaloneEngineFacade.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/engine/StandaloneEngineFacade.java
@@ -20,7 +20,6 @@
 package org.sonarlint.eclipse.core.internal.engine;
 
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -34,18 +33,13 @@ import org.sonarlint.eclipse.core.internal.jobs.WrappedProgressMonitor;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
 import org.sonarsource.sonarlint.core.StandaloneSonarLintEngineImpl;
 import org.sonarsource.sonarlint.core.analysis.api.AnalysisResults;
-import org.sonarsource.sonarlint.core.client.api.common.RuleDetails;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.IssueListener;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneAnalysisConfiguration;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneGlobalConfiguration;
-import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
 import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneSonarLintEngine;
 import org.sonarsource.sonarlint.core.commons.Language;
 
-import static java.util.Collections.emptySet;
-
 public class StandaloneEngineFacade {
-
   @Nullable
   private StandaloneSonarLintEngine wrappedEngine;
 
@@ -89,21 +83,10 @@ public class StandaloneEngineFacade {
     }).orElseThrow(() -> new IllegalStateException("SonarLint Engine not available"));
   }
 
-  @Nullable
-  public RuleDetails getRuleDescription(String ruleKey) {
-    return withEngine(engine -> engine.getRuleDetails(ruleKey).orElse(null)).orElse(null);
-  }
-
-  public Collection<StandaloneRuleDetails> getAllRuleDetails() {
-    return withEngine(StandaloneSonarLintEngine::getAllRuleDetails)
-      .orElse(emptySet());
-  }
-
   public synchronized void stop() {
     if (wrappedEngine != null) {
       wrappedEngine.stop();
       wrappedEngine = null;
     }
   }
-
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
@@ -42,7 +42,7 @@ import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfigurat
 import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
 import org.sonarlint.eclipse.core.internal.utils.BundleUtils;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
-import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.RuleDefinitionDto;
 import org.sonarsource.sonarlint.core.commons.Language;
 import org.sonarsource.sonarlint.core.telemetry.InternalDebug;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryClientAttributesProvider;
@@ -170,11 +170,16 @@ public class SonarLintTelemetry {
     }
 
     private static Set<String> defaultEnabledRuleKeys() {
-      return SonarLintCorePlugin.getInstance().getDefaultSonarLintClientFacade()
-        .getAllRuleDetails().stream()
-        .filter(StandaloneRuleDetails::isActiveByDefault)
-        .map(StandaloneRuleDetails::getKey)
-        .collect(Collectors.toSet());
+      try {
+        return SonarLintBackendService.get().getStandaloneRules().get().getRulesByKey().values().stream()
+          .filter(RuleDefinitionDto::isActiveByDefault)
+          .map(RuleDefinitionDto::getKey)
+          .collect(Collectors.toSet());
+      } catch (Exception err) {
+        SonarLintLogger.get().error("Loading all standalone rules for telemetry failed", err);
+      }
+      
+      return Collections.emptySet();
     }
 
     @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
@@ -19,7 +19,10 @@
  */
 package org.sonarlint.eclipse.ui.internal.properties;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
@@ -28,13 +31,14 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.dialogs.PropertyPage;
-import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.TriggerType;
+import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
 import org.sonarlint.eclipse.core.internal.preferences.RuleConfig;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.binding.actions.AnalysisJobsScheduler;
-import org.sonarsource.sonarlint.core.client.api.standalone.StandaloneRuleDetails;
+import org.sonarsource.sonarlint.core.clientapi.backend.rules.RuleDefinitionDto;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 
 public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPreferencePage {
 
@@ -66,8 +70,14 @@ public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPr
     return pageComponent;
   }
 
-  private static Collection<StandaloneRuleDetails> loadRuleDetails() {
-    return SonarLintCorePlugin.getInstance().getDefaultSonarLintClientFacade().getAllRuleDetails();
+  private static List<RuleDefinitionDto> loadRuleDetails() {
+    try {
+      return new ArrayList<>(SonarLintBackendService.get().getStandaloneRules().get().getRulesByKey().values());
+    } catch (Exception err) {
+      SonarLintLogger.get().error("Loading all standalone rules for the configuration page failed", err);
+    }
+    
+    return Collections.emptyList();
   }
 
   @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
@@ -110,31 +111,38 @@ public class RuleDetailsPanel extends Composite {
   }
 
   public void updateRule(GetStandaloneRuleDescriptionResponse getStandaloneRuleDescriptionResponse) {
-    var ruleDefinition = getStandaloneRuleDescriptionResponse.getRuleDefinition();
+    try {
+      var ruleDefinition = getStandaloneRuleDescriptionResponse.getRuleDefinition();
 
-    ruleNameLabel.setText(ruleDefinition.getName());
-    ruleNameLabel.requestLayout();
-    ruleHeaderPanel.updateRule(ruleDefinition.getKey(), ruleDefinition.getType(), ruleDefinition.getDefaultSeverity());
+      ruleNameLabel.setText(ruleDefinition.getName());
+      ruleNameLabel.requestLayout();
+      ruleHeaderPanel.updateRule(ruleDefinition.getKey(), ruleDefinition.getType(), ruleDefinition.getDefaultSeverity());
 
-    updateHtmlDescription(getStandaloneRuleDescriptionResponse.getDescription(), ruleDefinition.getLanguage().getLanguageKey());
+      updateHtmlDescription(getStandaloneRuleDescriptionResponse.getDescription(), ruleDefinition.getLanguage().getLanguageKey());
 
-    requestLayout();
-    updateScrollCompositeMinSize();
+      requestLayout();
+      updateScrollCompositeMinSize();
+    } catch (SWTException ignored) {
+      // There might be a race condition between the background job running late and the view already being closed
+    }
   }
 
   public void updateRule(GetEffectiveRuleDetailsResponse getEffectiveRuleDetailsResponse) {
-    var details = getEffectiveRuleDetailsResponse.details();
+    try {
+      var details = getEffectiveRuleDetailsResponse.details();
 
-    ruleNameLabel.setText(details.getName());
-    ruleNameLabel.requestLayout();
-    ruleHeaderPanel.updateRule(details.getKey(), details.getType(), details.getSeverity());
+      ruleNameLabel.setText(details.getName());
+      ruleNameLabel.requestLayout();
+      ruleHeaderPanel.updateRule(details.getKey(), details.getType(), details.getSeverity());
 
-    updateHtmlDescription(details.getDescription(), details.getLanguage().getLanguageKey());
+      updateHtmlDescription(details.getDescription(), details.getLanguage().getLanguageKey());
+      updateParameters(details);
 
-    updateParameters(details);
-
-    requestLayout();
-    updateScrollCompositeMinSize();
+      requestLayout();
+      updateScrollCompositeMinSize();
+    } catch (SWTException ignored) {
+      // There might be a race condition between the background job running late and the view already being closed
+    }
   }
 
   private void updateParameters(EffectiveRuleDetailsDto details) {


### PR DESCRIPTION
*SonarLint for Eclipse* does not rely on the deprecated methods from `StandaloneSonarLintEngine` from *SonarLint Core* anymore.