### PR TITLE
NO-JIRA: Eclipse user survey

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -279,7 +279,7 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
       }
       
       // Display user survey pop-up (comment out if not needed, comment in again if needed and replace link)
-      SurveyPopup.displaySurveyPopupIfNotAlreadyAccessed("https://forms.gle/EdAJf5sdJDvDT6dNA");
+      Display.getDefault().syncExec(() -> SurveyPopup.displaySurveyPopupIfNotAlreadyAccessed("https://forms.gle/EdAJf5sdJDvDT6dNA"));
 
       return Status.OK_STATUS;
     }


### PR DESCRIPTION
Definitely run in the UI thread! I was assuming that due to the `StartupJob` it would automatically run on the UI thread, but that was not the case: The build passed without any issues, and manual testing was done as well, but noticed in validation with other Eclipse versions that it is a "flaky" issue based on Eclipse deciding where to run stuff.