### PR TITLE
BUILD-3911: Upload JUnit Plug-in Test logs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,6 +114,8 @@ validate_task:
     /etc/init.d/xvfb stop
   cleanup_before_cache_script: cleanup_maven_repository
   on_failure:
+    mvn_log_artifacts:
+      path: "${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/work/data/.metadata/.log"
     xvfb_log_artifacts:
       path: "${CIRRUS_WORKING_DIR}/Xvfb.out"
     junit_artifacts:


### PR DESCRIPTION
When running the "unit" tests we face the issue that on failures prior to running the tests (setting up environment) or after (tearing down environment) the log is not printed to the console but to the specific workspace file.

@matemoln while just forwarding the file content to the console was possible, it was very messy as the log can be quite huge.