### PR TITLE
SLE-747: IDE to server path matching failure

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/ProjectIssueTracker.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/tracking/ProjectIssueTracker.java
@@ -127,11 +127,20 @@ public class ProjectIssueTracker {
 
     for (var issuable : issuables) {
       if (issuable instanceof ISonarLintFile) {
-        var file = ((ISonarLintFile) issuable);
+        var relativePath = ((ISonarLintFile) issuable).getProjectRelativePath();
 
-        var serverRelativePath = IssueStorePaths.idePathToServerPath(projectBinding, file.getProjectRelativePath());
-        var localIssuesTracked = trackedIssuesPerRelativePath.get(file.getProjectRelativePath());
-        issuesDtos.put(serverRelativePath, localIssuesTracked.stream().map(ProjectIssueTracker::convertFromTrackable).collect(Collectors.toList()));
+        var serverRelativePath = IssueStorePaths.idePathToServerPath(projectBinding, relativePath);
+        if (serverRelativePath != null) {
+          var localIssuesTracked = trackedIssuesPerRelativePath.get(relativePath);
+          issuesDtos.put(serverRelativePath,
+            localIssuesTracked.stream().map(ProjectIssueTracker::convertFromTrackable).collect(Collectors.toList()));
+        } else {
+          SonarLintLogger.get().debug("'" + relativePath
+            + "' cannot be converted from IDE to server path for project binding: '"
+            + projectBinding.projectKey() + "' / '"
+            + projectBinding.idePathPrefix() + "' / '"
+            + projectBinding.serverPathPrefix() + "'");
+        }
       }
     }
 


### PR DESCRIPTION
Handle the corner case in which a file with issues cannot be matched to server issues because the file itself does not comply with the server path.