### PR TITLE
SLE-745: Strip extra analyzer properties

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfigurationTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfigurationTest.java
@@ -59,7 +59,7 @@ public class SonarLintGlobalConfigurationTest extends SonarTestCase {
   public void should_serialize_extra_properties() {
     var list = List.of(
       new SonarLintProperty("key1", "value1"),
-      new SonarLintProperty("key2", "value2"));
+      new SonarLintProperty("key2   ", "value2   "));
 
     var serialized = SonarLintGlobalConfiguration.serializeExtraProperties(list);
     var desList = SonarLintGlobalConfiguration.deserializeExtraProperties(serialized);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProperty.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/SonarLintProperty.java
@@ -24,13 +24,12 @@ public class SonarLintProperty {
   private String value;
 
   public SonarLintProperty(String name, String value) {
-    this.name = name;
-    this.value = value;
+    this.name = name.strip();
+    this.value = value.strip();
   }
 
   public SonarLintProperty(SonarLintProperty another) {
-    this.name = another.name;
-    this.value = another.value;
+    this(another.name, another.value);
   }
 
   public String getName() {


### PR DESCRIPTION
We don't want to have extra analyzer properties containing some form of white spaces (which can cause issues), therefore we strip everything when saving them.