### PR TITLE
SLE-720: Show soon unsupported SQ connection notification

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/AbstractSonarLintTest.java
+++ b/its/src/org/sonarlint/eclipse/its/AbstractSonarLintTest.java
@@ -113,6 +113,17 @@ public abstract class AbstractSonarLintTest {
       new DefaultShell("Default Eclipse preferences for PyDev").close();
     } catch (Exception ignored) {
     }
+    
+    // remove warning about soon unsupported version (there can be multiple)
+    if ("oldest".equals(System.getProperty("target.platform"))) {
+      while (true) {
+        try {
+          new DefaultShell("SonarQube - Soon unsupported version").close();
+        } catch (Exception ignored) {
+          break;
+        }
+      }
+    }
 
     var consoleView = new SonarLintConsole();
     System.out.println(consoleView.getConsoleView().getConsoleText());

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -20,6 +20,7 @@
 package org.sonarlint.eclipse.core.internal.preferences;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -78,6 +79,7 @@ public class SonarLintGlobalConfiguration {
   private static final String PREF_TAINT_VULNERABILITY_DISPLAYED = "taintVulnerabilityDisplayed";
   private static final String PREF_SECRETS_EVER_DETECTED = "secretsEverDetected";
   private static final String PREF_USER_SURVEY_LAST_LINK = "userSurveyLastLink"; //$NON-NLS-1$
+  private static final String PREF_SOON_UNSUPPORTED_CONNECTIONS = "soonUnsupportedSonarQubeConnections"; //$NON-NLS-1$
 
   private SonarLintGlobalConfiguration() {
     // Utility class
@@ -317,13 +319,37 @@ public class SonarLintGlobalConfiguration {
     setPreferenceBoolean(PREF_SECRETS_EVER_DETECTED, true);
   }
 
-  /** See {@link org.sonarlint.eclipse.ui.internal.survey.SurveyPopup} for more information */
+  /** See {@link org.sonarlint.eclipse.ui.internal.popup.SurveyPopup} for more information */
   public static String getUserSurveyLastLink() {
     return getPreferenceString(PREF_USER_SURVEY_LAST_LINK);
   }
   
-  /** See {@link org.sonarlint.eclipse.ui.internal.survey.SurveyPopup} for more information */
+  /** See {@link org.sonarlint.eclipse.ui.internal.popup.SurveyPopup} for more information */
   public static void setUserSurveyLastLink(String link) {
     setPreferenceString(PREF_USER_SURVEY_LAST_LINK, link);
+  }
+  
+  /** See {@link org.sonarlint.eclipse.ui.internal.popup.SoonUnsupportedPopup} for more information */
+  public static boolean alreadySoonUnsupportedConnection(String connectionVersionCombination) {
+    var currentPreference = getPreferenceString(PREF_SOON_UNSUPPORTED_CONNECTIONS);
+    if (PREF_DEFAULT.equals(currentPreference)) {
+      return false;
+    }
+    
+    return Set.of(currentPreference.split(",")).contains(connectionVersionCombination);
+  }
+  
+  /** See {@link org.sonarlint.eclipse.ui.internal.popup.SoonUnsupportedPopup} for more information */
+  public static void addSoonUnsupportedConnection(String connectionVersionCombination) {
+    var currentPreference = getPreferenceString(PREF_SOON_UNSUPPORTED_CONNECTIONS);
+    if (PREF_DEFAULT.equals(currentPreference)) {
+      setPreferenceString(PREF_SOON_UNSUPPORTED_CONNECTIONS, connectionVersionCombination);
+      return;
+    }
+    
+    var currentConnections = new HashSet<String>(Arrays.asList(currentPreference.split(",")));
+    currentConnections.add(connectionVersionCombination);
+    
+    setPreferenceString(PREF_SOON_UNSUPPORTED_CONNECTIONS, String.join(",", currentConnections));
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
@@ -43,6 +43,7 @@ import org.sonarlint.eclipse.core.internal.engine.connected.ConnectedEngineFacad
 import org.sonarlint.eclipse.core.internal.engine.connected.IConnectedEngineFacade;
 import org.sonarlint.eclipse.core.internal.jobs.TaintIssuesUpdateAfterSyncJob;
 import org.sonarlint.eclipse.core.internal.markers.MarkerUtils;
+import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
 import org.sonarlint.eclipse.core.resource.ISonarLintFile;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
@@ -58,6 +59,7 @@ import org.sonarlint.eclipse.ui.internal.popup.BindingSuggestionPopup;
 import org.sonarlint.eclipse.ui.internal.popup.DeveloperNotificationPopup;
 import org.sonarlint.eclipse.ui.internal.popup.MessagePopup;
 import org.sonarlint.eclipse.ui.internal.popup.SingleBindingSuggestionPopup;
+import org.sonarlint.eclipse.ui.internal.popup.SoonUnsupportedPopup;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 import org.sonarlint.eclipse.ui.internal.util.DisplayUtils;
 import org.sonarlint.eclipse.ui.internal.util.PlatformUtils;
@@ -319,7 +321,17 @@ public class SonarLintEclipseClient extends SonarLintEclipseHeadlessClient {
 
   @Override
   public void showSoonUnsupportedMessage(ShowSoonUnsupportedMessageParams params) {
-    // Not yet implemented
+    var connectionVersionCombination = params.getDoNotShowAgainId();
+    if (SonarLintGlobalConfiguration.alreadySoonUnsupportedConnection(connectionVersionCombination)) {
+      return;
+    }
+    
+    Display.getDefault().syncExec(() -> {
+      var popup = new SoonUnsupportedPopup(params.getDoNotShowAgainId(), params.getText());
+      popup.setFadingEnabled(false);
+      popup.setDelayClose(0L);
+      popup.open();
+    });
   }
 
   @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/documentation/SonarLintDocumentation.java
@@ -22,6 +22,7 @@ package org.sonarlint.eclipse.ui.internal.documentation;
 public class SonarLintDocumentation {
   private static final String BASE_DOCS_URL = "https://docs.sonarsource.com/sonarlint/eclipse";
   public static final String CONNECTED_MODE_LINK = BASE_DOCS_URL + "/team-features/connected-mode/";
+  public static final String VERSION_SUPPORT_POLICY = BASE_DOCS_URL + "/team-features/connected-mode/#sonarlint-sonarqube-version-support-policy";
   public static final String SECURITY_HOTSPOTS_LINK = BASE_DOCS_URL + "/using-sonarlint/security-hotspots/";
   public static final String TAINT_VULNERABILITIES_LINK = BASE_DOCS_URL + "/using-sonarlint/taint-vulnerabilities/";
   public static final String ON_THE_FLY_VIEW_LINK = BASE_DOCS_URL + "/using-sonarlint/investigating-issues/#the-on-the-fly-view";

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SoonUnsupportedPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SoonUnsupportedPopup.java
@@ -1,0 +1,64 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.popup;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
+import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarlint.eclipse.ui.internal.documentation.SonarLintDocumentation;
+import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
+
+/** Popup indicating that there is a connection in the workspace to a soon unsupported SonarQube version */
+public class SoonUnsupportedPopup extends AbstractSonarLintPopup {
+  private final String doNotShowAgainId;
+  private final String message;
+  
+  public SoonUnsupportedPopup(String doNotShowAgainId, String message) {
+    this.doNotShowAgainId = doNotShowAgainId;
+    this.message = message;
+  }
+
+  @Override
+  protected String getMessage() {
+    return message;
+  }
+  
+  @Override
+  protected void createContentArea(Composite composite) {
+    super.createContentArea(composite);
+
+    addLink("Don't show again", e -> {
+      SonarLintGlobalConfiguration.addSoonUnsupportedConnection(doNotShowAgainId);
+      BrowserUtils.openExternalBrowser(SonarLintDocumentation.VERSION_SUPPORT_POLICY, getShell().getDisplay());
+      close();
+    });
+  }
+  
+  @Override
+  protected String getPopupShellTitle() {
+    return "SonarQube - Soon unsupported version";
+  }
+
+  @Override
+  protected Image getPopupShellImage(int maximumHeight) {
+    return SonarLintImages.SONARQUBE_SERVER_ICON_IMG;
+  }
+}


### PR DESCRIPTION
## Summary

When connected to a soon unsupported SonarQube server (second to last LTS) we display a notification to the user with the information on what and why. The user can acknowledge the information to not show it again, then he will also be forwarded to the SonarLint documentation page on that matter.

## Testing

Testing was done manually and is ensured by the integration tests targeting the **Oldest** target platform.