### PR TITLE
NO-JIRA: Remove Eclipse user survey

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -279,7 +279,7 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
       }
       
       // Display user survey pop-up (comment out if not needed, comment in again if needed and replace link)
-      Display.getDefault().syncExec(() -> SurveyPopup.displaySurveyPopupIfNotAlreadyAccessed("https://forms.gle/EdAJf5sdJDvDT6dNA"));
+      //Display.getDefault().syncExec(() -> SurveyPopup.displaySurveyPopupIfNotAlreadyAccessed(""));
 
       return Status.OK_STATUS;
     }


### PR DESCRIPTION
The current survey ends, therefore we remove it from being triggered on the user side. The code remains (commented out) in place for later use and/or when we refactor the survey mechanism to work via the SonarLint website.