### PR TITLE
SLE-752: Deprecate username/password authentication

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
@@ -65,6 +65,7 @@ import org.sonarlint.eclipse.its.reddeer.views.SonarLintTaintVulnerabilitiesView
 import org.sonarlint.eclipse.its.reddeer.wizards.MarkIssueAsDialog;
 import org.sonarlint.eclipse.its.reddeer.wizards.ProjectBindingWizard;
 import org.sonarlint.eclipse.its.reddeer.wizards.ServerConnectionWizard;
+import org.sonarlint.eclipse.its.reddeer.wizards.ServerConnectionWizard.AuthenticationPage;
 import org.sonarqube.ws.QualityProfiles.SearchWsResponse.QualityProfile;
 import org.sonarqube.ws.client.PostRequest;
 import org.sonarqube.ws.client.permission.AddGroupWsRequest;
@@ -154,6 +155,9 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
     assertThat(wizard.isNextEnabled()).isFalse();
     authenticationPage.setPassword("wrong");
     assertThat(wizard.isNextEnabled()).isTrue();
+    
+    // until we change the ITs with the removal of the username / password authentication we check here once
+    assertThat(authenticationPage.getDeprecationMessage()).isEqualTo(authenticationPage.DEPRECATION_MESSAGE);
 
     wizard.next();
     new WaitUntil(new DialogMessageIsExpected(wizard, "Authentication failed"));

--- a/its/src/org/sonarlint/eclipse/its/reddeer/wizards/ServerConnectionWizard.java
+++ b/its/src/org/sonarlint/eclipse/its/reddeer/wizards/ServerConnectionWizard.java
@@ -26,6 +26,7 @@ import org.eclipse.reddeer.eclipse.selectionwizard.NewMenuWizard;
 import org.eclipse.reddeer.jface.wizard.WizardPage;
 import org.eclipse.reddeer.swt.impl.button.CheckBox;
 import org.eclipse.reddeer.swt.impl.button.RadioButton;
+import org.eclipse.reddeer.swt.impl.label.DefaultLabel;
 import org.eclipse.reddeer.swt.impl.table.DefaultTable;
 import org.eclipse.reddeer.swt.impl.text.DefaultText;
 import org.eclipse.swt.widgets.Table;
@@ -74,7 +75,9 @@ public class ServerConnectionWizard extends NewMenuWizard {
   }
 
   public static class AuthenticationPage extends WizardPage {
-
+    public final String DEPRECATION_MESSAGE = "Authentication via username and password is deprecated and will "
+      + "be removed in the future. Please use a token instead.";
+    
     public AuthenticationPage(ReferencedComposite referencedComposite) {
       super(referencedComposite);
     }
@@ -89,6 +92,10 @@ public class ServerConnectionWizard extends NewMenuWizard {
 
     public void setPassword(String password) {
       new DefaultText(this, 1).setText(password);
+    }
+    
+    public String getDeprecationMessage() {
+      return new DefaultLabel(this, 2).getText();
     }
   }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/UsernamePasswordWizardPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/UsernamePasswordWizardPage.java
@@ -24,17 +24,26 @@ import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.jface.databinding.fieldassist.ControlDecorationSupport;
 import org.eclipse.jface.databinding.wizard.WizardPageSupport;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.sonarlint.eclipse.ui.internal.Messages;
+import org.sonarlint.eclipse.ui.internal.SonarLintImages;
 import org.sonarlint.eclipse.ui.internal.util.wizard.BeanPropertiesCompat;
 import org.sonarlint.eclipse.ui.internal.util.wizard.WidgetPropertiesCompat;
 
+/**
+ *  @deprecated SonarCloud only offers authentication via token, SonarQube should follow soon
+ */
+@Deprecated(since="9.1", forRemoval=true)
 public class UsernamePasswordWizardPage extends AbstractServerConnectionWizardPage {
-
+  public static final String DEPRECATION_MESSAGE = "Authentication via username and password is deprecated and will "
+    + "be removed in the future. Please use a token instead.";
+  
   private Text serverUsernameText;
   private Text serverPasswordText;
 
@@ -49,6 +58,7 @@ public class UsernamePasswordWizardPage extends AbstractServerConnectionWizardPa
   @SuppressWarnings("unchecked")
   @Override
   protected void doCreateControl(Composite container) {
+    createDeprecationLabel(container);
     createUsernameOrTokenField(container);
     createPasswordField(container);
 
@@ -71,6 +81,23 @@ public class UsernamePasswordWizardPage extends AbstractServerConnectionWizardPa
     ControlDecorationSupport.create(passwordTextBinding, SWT.LEFT | SWT.TOP);
 
     WizardPageSupport.create(this, dataBindingContext);
+  }
+  
+  private static void createDeprecationLabel(final Composite container) {
+    var deprecationContainer = new Composite(container, SWT.NONE);
+    deprecationContainer.setLayout(new GridLayout(3, false));
+    deprecationContainer.setLayoutData(new GridData(SWT.LEFT, SWT.DOWN, true, false, Integer.MAX_VALUE, 1));
+    
+    // icon on the left
+    new Label(deprecationContainer, SWT.NULL).setImage(SonarLintImages.IMG_SEVERITY_BLOCKER);
+    
+    var labelDeprecation = new Label(deprecationContainer, SWT.NULL);
+    labelDeprecation.setText(DEPRECATION_MESSAGE);
+    labelDeprecation.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+    labelDeprecation.setFont(JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT));
+    
+    // icon on the right
+    new Label(deprecationContainer, SWT.NULL).setImage(SonarLintImages.IMG_SEVERITY_BLOCKER);
   }
 
   private void createPasswordField(final Composite container) {


### PR DESCRIPTION
Users should only use tokens when setting up / changing connections in the future. Until then we provide them with information that the method is going to be deprecated in the future!