### PR TITLE
NO-JIRA: Log information about incomplete markers

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
@@ -469,7 +469,7 @@ public class SonarLintMarkerUpdater {
         marker.setAttribute(IMarker.CHAR_START, flowPosition.getOffset());
         marker.setAttribute(IMarker.CHAR_END, flowPosition.getOffset() + flowPosition.getLength());
       } else {
-        SonarLintLogger.get().debug("Position cannot be set for flow on '" + file.getProjectRelativePath());
+        SonarLintLogger.get().debug("Position cannot be set for flow on '" + file.getProjectRelativePath() + "'");
       }
       return marker;
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
@@ -280,6 +280,9 @@ public class SonarLintMarkerUpdater {
       if (position != null) {
         marker.setAttribute(IMarker.CHAR_START, position.getOffset());
         marker.setAttribute(IMarker.CHAR_END, position.getOffset() + position.getLength());
+      } else {
+        SonarLintLogger.get().debug("Position cannot be set for taint issue '" + taintIssue.getKey() + "' in '"
+          + taintIssue.getFilePath() + "'");
       }
 
       marker.setAttribute(IMarker.PRIORITY, getPriority(taintIssue.getSeverity()));
@@ -406,6 +409,8 @@ public class SonarLintMarkerUpdater {
         if (position != null) {
           marker.setAttribute(IMarker.CHAR_START, position.getOffset());
           marker.setAttribute(IMarker.CHAR_END, position.getOffset() + position.getLength());
+        } else {
+          SonarLintLogger.get().debug("Position cannot be set on resource '" + resource.getFullPath());
         }
       }
       return Optional.of(marker);
@@ -463,6 +468,8 @@ public class SonarLintMarkerUpdater {
       if (flowPosition != null) {
         marker.setAttribute(IMarker.CHAR_START, flowPosition.getOffset());
         marker.setAttribute(IMarker.CHAR_END, flowPosition.getOffset() + flowPosition.getLength());
+      } else {
+        SonarLintLogger.get().debug("Position cannot be set for flow on '" + file.getProjectRelativePath());
       }
       return marker;
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
@@ -410,7 +410,7 @@ public class SonarLintMarkerUpdater {
           marker.setAttribute(IMarker.CHAR_START, position.getOffset());
           marker.setAttribute(IMarker.CHAR_END, position.getOffset() + position.getLength());
         } else {
-          SonarLintLogger.get().debug("Position cannot be set on resource '" + resource.getFullPath());
+          SonarLintLogger.get().debug("Position cannot be set on resource '" + resource.getFullPath() + "'");
         }
       }
       return Optional.of(marker);


### PR DESCRIPTION
This is based on the issue mentioned in this [Community Forum Thread](https://community.sonarsource.com/t/errors-and-seemingly-successful-analysis/105232). It is nice that we log the stack trace and the text range but we don't log the file/resource and the circumstances it is happening on - making it hard to debug such cases where it is not clear if the issue is coming from SonarLint or one of the language analyzers.