### PR TITLE
SLE-784: Don't fail on incorrect classpath

### DIFF
--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -258,7 +258,14 @@ public class JdtUtils {
     final String libPath;
     var member = findPath(javaProject.getProject(), entry.getPath());
     if (member != null) {
-      libPath = member.getLocation().toOSString();
+      var location = member.getLocation();
+      if (location == null) {
+        SonarLintLogger.get().error("Library at '" + entry.getPath() + "' could not be resolved correctly on project '"
+          + javaProject.getPath() + "' from workspace member: " + member);
+        return null;
+      }
+      
+      libPath = location.toOSString();
     } else {
       libPath = entry.getPath().makeAbsolute().toOSString();
     }


### PR DESCRIPTION
This is based on the issue mentioned in this [Community Forum Thread](https://community.sonarsource.com/t/nullpointerexception-org-eclipse-core-resources-iresource-getlocation-is-null/105303). When a Java project classpath file contains invalid library entries we should log them but not fail the analysis.