### PR TITLE
Fix Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,11 +149,11 @@ qa_task:
     - env:
         TARGET_PLATFORM: 'latest'
         SQ_VERSION: 'LATEST_RELEASE[9.9]'
-        QA_CATEGORY: 'Latest'
+        QA_CATEGORY: 'Latest-LTS'
     - env:
-        TARGET_PLATFORM: 'ibuilds'
+        TARGET_PLATFORM: 'latest'
         SQ_VERSION: 'DEV'
-        QA_CATEGORY: 'IBuilds'
+        QA_CATEGORY: 'Latest'
   <<: *SETUP_MAVEN_CACHE_QA
   download_staged_update_site_script: |
     set -euo pipefail
@@ -166,13 +166,13 @@ qa_task:
     metacity --sm-disable --replace &
     sleep 10 # give metacity some time to start
     echo 'Recording tests on video'
-    ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${TARGET_PLATFORM}.mp4
+    ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4
   run_its_script: |
     echo "Run Maven ITs for Eclipse ${TARGET_PLATFORM} and Server ${SQ_VERSION}"
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify -f its/pom.xml -Pcoverage \
       -Dtarget.platform=${TARGET_PLATFORM} -Dtycho.localArtifacts=ignore -Dsonarlint-eclipse.p2.url="file://${CIRRUS_WORKING_DIR}/staged-repository" -Dsonar.runtimeVersion=${SQ_VERSION} \
       -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/it-coverage.exec
-    mv it-coverage.exec it-coverage-${TARGET_PLATFORM}.exec
+    mv it-coverage.exec it-coverage-${QA_CATEGORY}.exec
   cleanup_before_cache_script: cleanup_maven_repository
   always:
     stop_recording_script: |
@@ -180,7 +180,7 @@ qa_task:
       while pgrep ffmpeg >/dev/null; do sleep 1; done
       /etc/init.d/xvfb stop
     test_recording_artifacts:
-      path: "${CIRRUS_WORKING_DIR}/recording_${TARGET_PLATFORM}.mp4"
+      path: "${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4"
     log_artifacts:
       path: "its/build/idea-sandbox/system/log"
     jacoco_artifacts:

--- a/its/src/org/sonarlint/eclipse/its/OpenInIdeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/OpenInIdeTest.java
@@ -54,7 +54,7 @@ import org.sonarqube.ws.client.project.DeleteRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- *  Integration tests on the "Open in IDE" feature only available on ibuilds as it is available since SonarQube 10.2+
+ *  Integration tests on the "Open in IDE" feature only available since SonarQube 10.2+
  */
 public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
   private static final String MAVEN_TAINT_PROJECT_KEY = "maven-taint";
@@ -86,7 +86,7 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
   /** as we re-use the same project we have to delete it on SonarQube after every test */
   @After
   public void deleteSonarQubeProjects() {
-    if ("ibuilds".equals(System.getProperty("target.platform", "ibuilds"))) {
+    if (orchestrator.getServer().version().isGreaterThanOrEquals(10, 2)) {
       adminWsClient.projects().delete(DeleteRequest.builder().setKey(MAVEN_TAINT_PROJECT_KEY).build());
     }
   }
@@ -94,8 +94,8 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
   /** integration test for when the feature fails due to the local file not being found */
   @Test
   public void test_open_in_ide_without_corner_cases() throws IOException, InterruptedException {
-    // Only available since SonarQube 10.2+ (ibuilds / locally)
-    Assume.assumeTrue("ibuilds".equals(System.getProperty("target.platform", "ibuilds")));
+    // Only available since SonarQube 10.2+ (LATEST_RELEASE / locally)
+    Assume.assumeTrue(orchestrator.getServer().version().isGreaterThanOrEquals(10, 2));
     
     // 1) create project on server / run first analysis
     createProjectOnSonarQube(orchestrator, MAVEN_TAINT_PROJECT_KEY, "SonarLint IT New Code");

--- a/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
+++ b/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
@@ -50,6 +50,7 @@ import org.eclipse.reddeer.workbench.impl.editor.TextEditor;
 import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.hamcrest.core.StringContains;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.sonarlint.eclipse.its.reddeer.conditions.OnTheFlyViewIsEmpty;
@@ -266,10 +267,11 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
 
   // Need PyDev
   @Test
+  @Ignore("12/2023: Removal of iBuilds axis, PyDev has to be updated in latest.target to work")
   @Category(RequiresExtraDependency.class)
   public void shouldAnalysePython() {
-    // The PydevPerspective is not working correctly in older PyDev versions, therefore only run in iBuilds
-    Assume.assumeTrue("ibuilds".equals(System.getProperty("target.platform", "ibuilds")));
+    // The PydevPerspective is not working correctly in older PyDev versions, therefore only run in latest
+    Assume.assumeTrue("latest".equals(System.getProperty("target.platform", "latest")));
     
     new PydevPerspective().open();
     importExistingProjectIntoWorkspace("python");


### PR DESCRIPTION
iBuilds are failing as we are depending on external dependencies for this axis (Eclipse IDE). iBuilds axis is removed and will be managed in a separate ticket to have an axis we can trigger manually for testing.

This separate ticket is [SLE-786](https://sonarsource.atlassian.net/browse/SLE-786).

[SLE-786]: https://sonarsource.atlassian.net/browse/SLE-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ