### PR TITLE
SLE-791: Automated connected mode setup

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -164,8 +164,8 @@
           <appArgLine>-eclipse.keyring target/keyring -eclipse.password secure-storage-password.txt -pluginCustomization
             ${project.basedir}/plugin_customization.ini</appArgLine>
           
-          <!-- Kill test JVM if tests take more than 45 minutes (2700 seconds) to finish -->
-          <forkedProcessTimeoutInSeconds>2700</forkedProcessTimeoutInSeconds>
+          <!-- Kill test JVM if tests take more than 60 minutes (3600 seconds) to finish -->
+          <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
           
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemProperties>

--- a/its/src/org/sonarlint/eclipse/its/AbstractSonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/AbstractSonarQubeConnectedModeTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
   }
   
   /** Create a project on SonarQube via Web API with corresponding quality profile assigned */
-  public void createProjectOnSonarQube(OrchestratorRule orchestrator, String projectKey, String qualityProfile) {
+  public static void createProjectOnSonarQube(OrchestratorRule orchestrator, String projectKey, String qualityProfile) {
     adminWsClient.projects()
       .create(CreateRequest.builder()
         .setName(projectKey)
@@ -84,7 +84,7 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
   }
   
   /** Run Maven build on specific project in folder with optional additional analysis properties */
-  public void runMavenBuild(OrchestratorRule orchestrator, String projectKey, String folder, String path,
+  public static void runMavenBuild(OrchestratorRule orchestrator, String projectKey, String folder, String path,
     Map<String, String> analysisProperties) {
     var build = MavenBuild.create(new File(folder, path))
       .setCleanPackageSonarGoals()

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
@@ -1,0 +1,43 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.binding.assist;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
+import org.sonarlint.eclipse.core.internal.engine.connected.IConnectedEngineFacade;
+import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnectionModel;
+
+public class AssistCreatingAutomaticConnectionJob extends AbstractAssistCreatingConnectionJob {
+  private final String tokenValue;
+  
+  public AssistCreatingAutomaticConnectionJob(String serverUrl, String tokenValue) {
+    super("Assist automatic creation of connected mode", serverUrl, true);
+    this.tokenValue = tokenValue;
+  }
+
+  @Override
+  @Nullable
+  protected IConnectedEngineFacade createConnection(ServerConnectionModel model) {
+    var connection = SonarLintCorePlugin.getServersManager().create(model.getConnectionId(), model.getServerUrl(),
+      model.getOrganization(), tokenValue, model.getPassword(), model.getNotificationsDisabled());
+    SonarLintCorePlugin.getServersManager().addServer(connection, tokenValue, model.getPassword());
+    return connection;
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
@@ -36,7 +36,7 @@ public class AssistCreatingAutomaticConnectionJob extends AbstractAssistCreating
   @Nullable
   protected IConnectedEngineFacade createConnection(ServerConnectionModel model) {
     var connection = SonarLintCorePlugin.getServersManager().create(model.getConnectionId(), model.getServerUrl(),
-      model.getOrganization(), tokenValue, model.getPassword(), model.getNotificationsDisabled());
+      model.getOrganization(), tokenValue, null, model.getNotificationsDisabled());
     SonarLintCorePlugin.getServersManager().addServer(connection, tokenValue, model.getPassword());
     return connection;
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingManualConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingManualConnectionJob.java
@@ -1,0 +1,43 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2023 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.binding.assist;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.ui.PlatformUI;
+import org.sonarlint.eclipse.core.internal.engine.connected.IConnectedEngineFacade;
+import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnectionModel;
+import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnectionWizard;
+
+public class AssistCreatingManualConnectionJob extends AbstractAssistCreatingConnectionJob {
+  public AssistCreatingManualConnectionJob(String serverUrl) {
+    super("Assist manual creation of connected mode", serverUrl, false);
+  }
+
+  @Override
+  @Nullable
+  protected IConnectedEngineFacade createConnection(ServerConnectionModel model) {
+    var wizard = new ServerConnectionWizard(model);
+    wizard.setSkipBindingWizard(true);
+    var dialog = ServerConnectionWizard.createDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), wizard);
+    dialog.setBlockOnOpen(true);
+    dialog.open();
+    return wizard.getResultServer();
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmConnectionCreationDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmConnectionCreationDialog.java
@@ -31,10 +31,12 @@ import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 
 class ConfirmConnectionCreationDialog extends MessageDialog {
 
-  public ConfirmConnectionCreationDialog(Shell parentShell, String serverUrl) {
-    super(parentShell, "Do you trust this SonarQube server?", SonarLintImages.BALLOON_IMG, "The \"" + serverUrl
-      + "\" server is attempting to set up a connection with SonarLint. Letting SonarLint connect to an untrusted server is potentially dangerous.", MessageDialog.WARNING,
-      new String[] {"Connect to this SonarQube server", "I don't trust this server"}, 0);
+  public ConfirmConnectionCreationDialog(Shell parentShell, String serverUrl, boolean automaticSetUp) {
+    super(parentShell, "Do you trust this SonarQube server?", SonarLintImages.BALLOON_IMG,
+      "The server at \"" + serverUrl + "\" is attempting to set up a connection with SonarLint. Letting SonarLint "
+      + "connect to an untrusted server is potentially dangerous."
+      + (automaticSetUp ? " The following setup will be done automatically." : ""),
+      MessageDialog.WARNING, new String[] {"Connect to this SonarQube server", "I don't trust this server"}, 0);
   }
 
   @Override

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -17,7 +17,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
 				  <artifactId>sonarlint-core-osgi</artifactId>
-				  <version>9.6.0.76599</version>
+				  <version>9.7.0.76760</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
## Summary

When running "Open in IDE" with SonarQube 10.4+, we can automatically set up connected mode. This helps the user to have a minimal solution for configuration.

## Testing

Integration tests were added to the already existing "Open in IDE" tests, and the whole test suite was overhauled to only create a project once on SQ and to run Maven only once in order to save [precious](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQRs65wa-OyfSBvrvzmqkQfUR4fz44neeZniGmOIXy07A&s) build time.