### PR TITLE
SLE-799: Overhaul rules configuration messaging

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
@@ -34,6 +34,7 @@ public class SonarLintDocumentation {
   public static final String MARK_ISSUES_LINK = BASE_DOCS_URL + "/using-sonarlint/fixing-issues/#marking-issues";
   public static final String FILE_EXCLUSIONS = BASE_DOCS_URL + "/using-sonarlint/file-exclusions/";
   public static final String RULES = BASE_DOCS_URL + "/using-sonarlint/rules/";
+  public static final String RULES_SELECTION = RULES + "#rule-selection";
   public static final String TROUBLESHOOTING_LINK = BASE_DOCS_URL + "/troubleshooting/";
 
   private static final String BASE_MARKETING_URL = "https://www.sonarsource.com";

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeConnectedProjectJob.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalyzeConnectedProjectJob.java
@@ -58,7 +58,7 @@ public class AnalyzeConnectedProjectJob extends AbstractAnalyzeProjectJob<Connec
 
   @Override
   protected ConnectedAnalysisConfiguration prepareAnalysisConfig(Path projectBaseDir, List<ClientInputFile> inputFiles, Map<String, String> mergedExtraProps) {
-    SonarLintLogger.get().debug("Connected mode (using configuration of '" + binding.projectKey() + "' in connection '" + binding.connectionId() + "')");
+    SonarLintLogger.get().debug("Connected Mode (using configuration of '" + binding.projectKey() + "' in connection '" + binding.connectionId() + "')");
     return ConnectedAnalysisConfiguration.builder()
       .setProjectKey(binding.projectKey())
       .setBaseDir(projectBaseDir)

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
@@ -51,7 +51,7 @@ public class ProjectsProviderUtils {
     var allProjects = allProjects();
     var numberOfAllProjects = allProjects.size();
     var boundProjects = allProjects.stream()
-      .filter(prj -> SonarLintCorePlugin.getServersManager().resolveBinding(prj).isPresent())
+      .filter(prj -> SonarLintCorePlugin.getConnectionManager().resolveBinding(prj).isPresent())
       .collect(Collectors.toSet());
     var numberOfBoundProjects = boundProjects.size();
     return numberOfAllProjects == 0 ? 0 : (numberOfBoundProjects / numberOfAllProjects);
@@ -59,6 +59,6 @@ public class ProjectsProviderUtils {
 
   public static Set<String> allConfigurationScopeIds() {
     return allProjects().stream().map(ConfigScopeSynchronizer::getConfigScopeId)
-    .collect(Collectors.toSet());
+      .collect(Collectors.toSet());
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/ProjectsProviderUtils.java
@@ -22,6 +22,7 @@ package org.sonarlint.eclipse.core.internal.resources;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.backend.ConfigScopeSynchronizer;
 import org.sonarlint.eclipse.core.internal.extension.SonarLintExtensionTracker;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
@@ -38,6 +39,22 @@ public class ProjectsProviderUtils {
       .map(ISonarLintProjectsProvider::get)
       .flatMap(Collection::stream)
       .collect(Collectors.toSet());
+  }
+
+  /**
+   *  Useful when we want SonarLint to behave differently when
+   *  - no project bound (ret = 0)
+   *  - all projects bound (ret = 1)
+   *  - at least one project bound (0 < ret < 1)
+   */
+  public static float boundToAllProjectsRatio() {
+    var allProjects = allProjects();
+    var numberOfAllProjects = allProjects.size();
+    var boundProjects = allProjects.stream()
+      .filter(prj -> SonarLintCorePlugin.getServersManager().resolveBinding(prj).isPresent())
+      .collect(Collectors.toSet());
+    var numberOfBoundProjects = boundProjects.size();
+    return numberOfAllProjects == 0 ? 0 : (numberOfBoundProjects / numberOfAllProjects);
   }
 
   public static Set<String> allConfigurationScopeIds() {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/LinkTelemetry.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/LinkTelemetry.java
@@ -23,10 +23,12 @@ import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 
 public enum LinkTelemetry {
 
+  RULES_SELECTION_DOCS("rulesSelectionDocs", SonarLintDocumentation.RULES_SELECTION),
   CONNECTED_MODE_DOCS("connectedModeDocs", SonarLintDocumentation.CONNECTED_MODE_LINK),
   COMPARE_SERVER_PRODUCTS("compareServerProducts", SonarLintDocumentation.COMPARE_SERVER_PRODUCTS_LINK),
   SONARQUBE_EDITIONS_DOWNLOADS("sonarQubeEditionsDownloads", SonarLintDocumentation.SONARQUBE_EDITIONS_LINK),
-  SONARCLOUD_PRODUCT_PAGE("sonarCloudProductPage", SonarLintDocumentation.SONARCLOUD_PRODUCT_LINK);
+  SONARCLOUD_PRODUCT_PAGE("sonarCloudProductPage", SonarLintDocumentation.SONARCLOUD_PRODUCT_LINK),
+  SONARCLOUD_SIGNUP_PAGE("sonarCloudSignUpPage", SonarLintDocumentation.SONARCLOUD_SIGNUP_LINK);
 
   private final String linkId;
   private final String url;

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingAutomaticConnectionJob.java
@@ -28,7 +28,7 @@ public class AssistCreatingAutomaticConnectionJob extends AbstractAssistCreating
   private final String tokenValue;
 
   public AssistCreatingAutomaticConnectionJob(String serverUrl, String tokenValue) {
-    super("Assist automatic creation of connected mode", serverUrl, true);
+    super("Assist automatic creation of Connected Mode", serverUrl, true);
     this.tokenValue = tokenValue;
   }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingManualConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AssistCreatingManualConnectionJob.java
@@ -27,7 +27,7 @@ import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnect
 
 public class AssistCreatingManualConnectionJob extends AbstractAssistCreatingConnectionJob {
   public AssistCreatingManualConnectionJob(String serverUrl) {
-    super("Assist manual creation of connected mode", serverUrl, false);
+    super("Assist manual creation of Connected Mode", serverUrl, false);
   }
 
   @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
@@ -1,0 +1,54 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.job;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
+import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
+import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
+import org.sonarlint.eclipse.ui.internal.util.MessageDialogUtils;
+
+/** Job triggered when the rules configuration page changes are saved in order to not block the UI */
+public class RulesConfigurationPageSaveJob extends Job {
+  public RulesConfigurationPageSaveJob() {
+    super("Saving the rules configuration");
+  }
+
+  @Override
+  protected IStatus run(IProgressMonitor monitor) {
+    var boundToAllProjectsRatio = ProjectsProviderUtils.boundToAllProjectsRatio();
+    if (boundToAllProjectsRatio == 1f) {
+      // all projects are bound, inform the user about local changes don't apply
+      MessageDialogUtils.connectedModeOnlyInformation("Changing rule configuration has no effect",
+        "As all the projects found in the workspace are already in connected mode, rule changes done locally "
+          + "will have no impact on the analysis and its results. This has to be done on SonarQube / SonarCloud.",
+        LinkTelemetry.RULES_SELECTION_DOCS);
+    } else if (!SonarLintGlobalConfiguration.ignoreEnhancedFeatureNotifications()) {
+      MessageDialogUtils.enhancedWithConnectedModeInformation("Are you working in a team?",
+        "When using Connected Mode you can benefit from having the rule configuration centralized. It is "
+          + "synchronized to all developers in your team, no manual configuration has to be done locally.");
+    }
+
+    return Status.OK_STATUS;
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
@@ -40,7 +40,7 @@ public class RulesConfigurationPageSaveJob extends Job {
     if (boundToAllProjectsRatio == 1f) {
       // all projects are bound, inform the user about local changes don't apply
       MessageDialogUtils.connectedModeOnlyInformation("Changing rule configuration has no effect",
-        "As all the projects found in the workspace are already in connected mode, rule changes done locally "
+        "As all the projects found in the workspace are already in Connected Mode, rule changes done locally "
           + "will have no impact on the analysis and its results. This has to be done on SonarQube / SonarCloud.",
         LinkTelemetry.RULES_SELECTION_DOCS);
     } else if (!SonarLintGlobalConfiguration.ignoreEnhancedFeatureNotifications()) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
@@ -46,7 +46,8 @@ public class RulesConfigurationPageSaveJob extends Job {
     } else if (!SonarLintGlobalConfiguration.ignoreEnhancedFeatureNotifications()) {
       MessageDialogUtils.enhancedWithConnectedModeInformation("Are you working in a team?",
         "When using Connected Mode you can benefit from having the rule configuration centralized. It is "
-          + "synchronized to all developers in your team, no manual configuration has to be done locally.");
+          + "synchronized to all project contributers using SonarLint, no manual configuration has to be done "
+          + "locally.");
     }
 
     return Status.OK_STATUS;

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/RulesConfigurationPageSaveJob.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
+import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils.WorkspaceProjectsBindingRatio;
 import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 import org.sonarlint.eclipse.ui.internal.util.MessageDialogUtils;
 
@@ -37,7 +38,7 @@ public class RulesConfigurationPageSaveJob extends Job {
   @Override
   protected IStatus run(IProgressMonitor monitor) {
     var boundToAllProjectsRatio = ProjectsProviderUtils.boundToAllProjectsRatio();
-    if (boundToAllProjectsRatio == 1f) {
+    if (boundToAllProjectsRatio == WorkspaceProjectsBindingRatio.ALL_BOUND) {
       // all projects are bound, inform the user about local changes don't apply
       MessageDialogUtils.connectedModeOnlyInformation("Changing rule configuration has no effect",
         "As all the projects found in the workspace are already in Connected Mode, rule changes done locally "

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
@@ -57,7 +57,7 @@ public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPr
 
   @Override
   public void init(IWorkbench workbench) {
-    setDescription("Configure rules used for SonarLint analysis for projects not in connected mode.");
+    setDescription("Configure rules used for SonarLint analysis for projects not in Connected Mode.");
   }
 
   @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
@@ -38,12 +38,10 @@ import org.sonarlint.eclipse.core.internal.TriggerType;
 import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
 import org.sonarlint.eclipse.core.internal.preferences.RuleConfig;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
-import org.sonarlint.eclipse.core.internal.resources.ProjectsProviderUtils;
-import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.binding.actions.AnalysisJobsScheduler;
+import org.sonarlint.eclipse.ui.internal.job.RulesConfigurationPageSaveJob;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
-import org.sonarlint.eclipse.ui.internal.util.MessageDialogUtils;
 import org.sonarsource.sonarlint.core.clientapi.backend.rules.RuleDefinitionDto;
 
 public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPreferencePage {
@@ -99,20 +97,7 @@ public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPr
     if (!newRuleConfigs.equals(initialRuleConfigs)) {
       initialRuleConfigs = newRuleConfigs;
       AnalysisJobsScheduler.scheduleAnalysisOfOpenFiles((ISonarLintProject) null, TriggerType.STANDALONE_CONFIG_CHANGE);
-
-      if (!SonarLintGlobalConfiguration.ignoreEnhancedFeatureNotifications()) {
-        if (ProjectsProviderUtils.boundToAllProjectsRatio() == 1f) {
-          // all projects are bound, inform the user about local changes don't apply
-          MessageDialogUtils.connectedModeOnlyInformation("Changing rule configuration has no effect",
-            "As all the projects found in the workspace are already in connected mode, rule changes done locally "
-              + "will have no impact on the analysis and its results! This has to be done on SonarQube / SonarCloud.",
-            LinkTelemetry.RULES_SELECTION_DOCS);
-        } else {
-          MessageDialogUtils.enhancedWithConnectedModeInformation("Are you working in a team?",
-            "When using Connected Mode you can benefit from having the rule configuration centralized. It is "
-              + "synchronized to all developers in your team, no manual configuration has to be done locally!");
-        }
-      }
+      new RulesConfigurationPageSaveJob().schedule();
     }
     return true;
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
@@ -138,7 +138,7 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
         .setText("Bound to the project '" + projectBinding.get().projectKey() + "' on connection '" + serverName(projectBinding.get().connectionId()) + "'");
       bindLink.setText("<a>Update project binding</a>");
     } else {
-      boundDetails.setText("Using SonarLint in connected mode with SonarQube/SonarCloud will offer you a lot of benefits. <a>Learn more</a>");
+      boundDetails.setText("Using SonarLint in Connected Mode with SonarQube/SonarCloud will offer you a lot of benefits. <a>Learn more</a>");
       bindLink.setText("<a>Bind this Eclipse project to SonarQube/SonarCloud...</a>");
     }
     if (projectBinding.isPresent() && SonarLintCorePlugin.getConnectionManager().resolveBinding(getProject()).isEmpty()) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/rule/RuleDetailsPanel.java
@@ -160,7 +160,7 @@ public class RuleDetailsPanel extends Composite {
 
       var link = new Link(ruleParamsPanel, SWT.NONE);
       link.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 2, 1));
-      link.setText("Parameter values can be set in <a>Rules Configuration</a>. In connected mode, server-side configuration overrides local settings.");
+      link.setText("Parameter values can be set in <a>Rules Configuration</a>. In Connected Mode, server-side configuration overrides local settings.");
       link.setFont(JFaceResources.getFontRegistry().getItalic(JFaceResources.DIALOG_FONT));
       link.addSelectionListener(new SelectionAdapter() {
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/trim/StatusWidget.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/trim/StatusWidget.java
@@ -113,7 +113,7 @@ public class StatusWidget extends WorkbenchWindowControlContribution {
     showViewSubMenu.add(new ShowViewAction("On-The-Fly", OnTheFlyIssuesView.ID, SonarLintImages.VIEW_ON_THE_FLY, "Display issues found by the on-the-fly analysis"));
     showViewSubMenu.add(new ShowViewAction("Report", SonarLintReportView.ID, SonarLintImages.VIEW_REPORT, "Display issues found by manually triggered analyses"));
     showViewSubMenu.add(new ShowViewAction("Rule Description", RuleDescriptionWebView.ID, SonarLintImages.VIEW_RULE, "Display rule description for the selected issue"));
-    showViewSubMenu.add(new ShowViewAction("Bindings", BindingsView.ID, SonarLintImages.VIEW_BINDINGS, "Allow to configure connections and bindings for SonarLint connected mode"));
+    showViewSubMenu.add(new ShowViewAction("Bindings", BindingsView.ID, SonarLintImages.VIEW_BINDINGS, "Allow to configure connections and bindings for SonarLint Connected Mode"));
     showViewSubMenu.add(new ShowViewAction("Security Hotspots", HotspotsView.ID, SonarLintImages.VIEW_HOTSPOTS, "Show security hotspots opened from SonarQube"));
     showViewSubMenu.add(new ShowViewAction("Issue locations", IssueLocationsView.ID, SonarLintImages.VIEW_LOCATIONS, "Show secondary locations or flows for the selected issue"));
     showViewSubMenu.add(new ShowViewAction("Taint Vulnerabilities", TaintVulnerabilitiesView.ID, SonarLintImages.VIEW_VULNERABILITIES,

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
@@ -23,8 +23,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
-import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
+import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 
 /** When we want to display simple dialogs we can use the JFace MessageDialog */
 public class MessageDialogUtils {
@@ -59,26 +59,40 @@ public class MessageDialogUtils {
 
   /** When not in UI thread, run it in UI thread */
   public static void enhancedWithConnectedModeInformation(String title, String message) {
-    Display.getDefault().asyncExec(() -> {
-      enhancedWithConnectedModeInformation(
-        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), title, message);
-    });
+    Display.getDefault().asyncExec(() -> enhancedWithConnectedModeInformation(
+      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), title, message));
   }
 
   /** For notifying about features enhances with connected mode we want to display some information */
   public static void enhancedWithConnectedModeInformation(Shell shell, String title, String message) {
     var result = new MessageDialog(shell, title, null,
       message, MessageDialog.INFORMATION,
-      new String[] { "Learn more" , "Try SonarCloud for free", "Don't ask again"}, 0).open();
+      new String[] {"Learn more", "Try SonarCloud for free", "Don't ask again"}, 0).open();
 
     // The result corresponds to the index in the array; totally confusing as the pre-selected button (in our case
     // "Learn more") is always the rightmost one.
     if (result == 0) {
-      BrowserUtils.openExternalBrowser(SonarLintDocumentation.CONNECTED_MODE_BENEFITS, shell.getDisplay());
+      BrowserUtils.openExternalBrowserWithTelemetry(LinkTelemetry.CONNECTED_MODE_DOCS, shell.getDisplay());
     } else if (result == 1) {
-      BrowserUtils.openExternalBrowser(SonarLintDocumentation.SONARCLOUD_SIGNUP_LINK, shell.getDisplay());
+      BrowserUtils.openExternalBrowserWithTelemetry(LinkTelemetry.SONARCLOUD_SIGNUP_PAGE, shell.getDisplay());
     } else {
       SonarLintGlobalConfiguration.setIgnoreEnhancedFeatureNotifications();
+    }
+  }
+
+  public static void connectedModeOnlyInformation(String title, String message, LinkTelemetry learnMoreLink) {
+    Display.getDefault().asyncExec(() -> connectedModeOnlyInformation(
+      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), title, message, learnMoreLink));
+  }
+
+  /** For notifying about features only in connected mode, link to the specific information */
+  public static void connectedModeOnlyInformation(Shell shell, String title, String message, LinkTelemetry learnMoreLink) {
+    var result = new MessageDialog(shell, title, null,
+      message, MessageDialog.INFORMATION,
+      new String[] {"Learn more", "Close"}, 0).open();
+
+    if (result == 0) {
+      BrowserUtils.openExternalBrowserWithTelemetry(learnMoreLink, shell.getDisplay());
     }
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
@@ -71,11 +71,12 @@ public class MessageDialogUtils {
 
     // The result corresponds to the index in the array; totally confusing as the pre-selected button (in our case
     // "Learn more") is always the rightmost one.
+    // INFO: When just closing the dialog, result will be greater than the array size, funny :D
     if (result == 0) {
       BrowserUtils.openExternalBrowserWithTelemetry(LinkTelemetry.CONNECTED_MODE_DOCS, shell.getDisplay());
     } else if (result == 1) {
       BrowserUtils.openExternalBrowserWithTelemetry(LinkTelemetry.SONARCLOUD_SIGNUP_PAGE, shell.getDisplay());
-    } else {
+    } else if (result == 2) {
       SonarLintGlobalConfiguration.setIgnoreEnhancedFeatureNotifications();
     }
   }


### PR DESCRIPTION
# Summary

The existing message plugged into the saving of the local rules configuration was overhauled in phrasing. Additionally, a switch was added for users configuring it despite all projects already bound.

# Testing

It was manually tested because Reddeer **always** expects [to come back to the main window after the preferences are closed](https://github.com/eclipse/reddeer/blob/master/plugins/org.eclipse.reddeer.jface/src/org/eclipse/reddeer/jface/preference/PreferenceDialog.java#L118-L120). It currently does not seem to support new shells popping up before the focus is back at the main window.

[THIS](https://github.com/eclipse/reddeer/issues/2227) issue was created. I've read in some threads that Reddeer is not maintained anymore but I didn't find anything official. Let's hope it is still maintained.