### PR TITLE
BUILD-4406: Consistent pipeline times

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -46,7 +46,7 @@ eks_builder_container: &BUILDER_CONTAINER_DEFINITION
     CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
-  builder_instance_type: t3.small
+  builder_instance_type: m6a.large
   builder_subnet_id: ${CIRRUS_AWS_SUBNET}
 
 maven_cache: &SETUP_MAVEN_CACHE
@@ -70,7 +70,8 @@ build_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 2G
+    memory: 8G
+    type: m6a.large
   env:
     ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
     ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
@@ -103,7 +104,8 @@ validate_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 4G
+    memory: 8G
+    type: m6a.large
   env:
     DEPLOY_PULL_REQUEST: false
     DISPLAY: :10
@@ -133,8 +135,9 @@ qa_task:
   <<: *ONLY_IF_EXCEPT_NIGHTLY
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
-    cpu: 4
+    cpu: 6
     memory: 12G
+    type: m6a.large
   env:
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
     GITHUB_TOKEN: VAULT[development/github/token/licenses-ro token]
@@ -204,7 +207,8 @@ sonarqube_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 4G
+    memory: 8G
+    type: m6a.large
   env:
     DEPLOY_PULL_REQUEST: false
     DISPLAY: :10
@@ -238,6 +242,7 @@ mend_scan_task:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
     memory: 8G
+    type: m6a.large
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
   <<: *SETUP_MAVEN_CACHE
@@ -261,7 +266,8 @@ promote_task:
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 2
-    memory: 1G
+    memory: 4G
+    type: m6a.large
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
@@ -282,7 +288,8 @@ dogfood_task:
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 2
-    memory: 1G
+    memory: 4G
+    type: m6a.large
   env:
     ARTIFACTORY_API_USER: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -47,8 +47,9 @@ qa_ibuilds_task:
   skip_notifications: true
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
-    cpu: 4
+    cpu: 6
     memory: 12G
+    type: m6a.large
   env:
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
     GITHUB_TOKEN: VAULT[development/github/token/licenses-ro token]


### PR DESCRIPTION
This is to be used as an intermediate solution. So we can continue with the optimization process on our side, we want to have build times that are not jumping up and down because Cirrus is choosing a build node type at random.