### PR TITLE
Fixed issues based on regression

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
@@ -219,11 +219,6 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
 
   @Test
   public void shouldFindSecretsInConnectedMode() {
-    // INFO: Currently disabled on 10.4 DEV as the sonar-text / sonar-text-enterprise artifacts supporting SonarLint
-    //       are not yet on master! After this was done, the test can be enabled again on this axis!
-    //       -> blocked by SONAR-21522
-    Assume.assumeTrue(!orchestrator.getServer().version().isGreaterThanOrEquals(10, 4));
-    
     adminWsClient.projects()
       .create(CreateRequest.builder()
         .setName(SECRET_JAVA_PROJECT_NAME)

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseClient.java
@@ -40,7 +40,6 @@ import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.TriggerType;
 import org.sonarlint.eclipse.core.internal.backend.ConfigScopeSynchronizer;
-import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
 import org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessClient;
 import org.sonarlint.eclipse.core.internal.engine.connected.ConnectionFacade;
 import org.sonarlint.eclipse.core.internal.jobs.TaintIssuesUpdateAfterSyncJob;
@@ -69,7 +68,6 @@ import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 import org.sonarlint.eclipse.ui.internal.util.DisplayUtils;
 import org.sonarlint.eclipse.ui.internal.util.PlatformUtils;
 import org.sonarsource.sonarlint.core.clientapi.backend.config.binding.BindingSuggestionDto;
-import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.RevokeTokenParams;
 import org.sonarsource.sonarlint.core.clientapi.client.OpenUrlInBrowserParams;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingParams;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingResponse;
@@ -188,12 +186,6 @@ public class SonarLintEclipseClient extends SonarLintEclipseHeadlessClient {
           return new AssistCreatingConnectionResponse(job.getConnectionId(),
             ProjectsProviderUtils.allConfigurationScopeIds());
         } else if (job.getResult().matches(IStatus.CANCEL)) {
-          if (job instanceof AssistCreatingAutomaticConnectionJob) {
-            SonarLintBackendService.get()
-              .getBackend()
-              .getUserTokenService()
-              .revokeToken(new RevokeTokenParams(baseUrl, params.getTokenName(), params.getTokenValue()));
-          }
           SonarLintLogger.get().debug("Assist creating connection was cancelled.");
         }
         throw new IllegalStateException(job.getResult().getMessage(), job.getResult().getException());

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/RulesConfigurationPage.java
@@ -97,7 +97,12 @@ public class RulesConfigurationPage extends PropertyPage implements IWorkbenchPr
     if (!newRuleConfigs.equals(initialRuleConfigs)) {
       initialRuleConfigs = newRuleConfigs;
       AnalysisJobsScheduler.scheduleAnalysisOfOpenFiles((ISonarLintProject) null, TriggerType.STANDALONE_CONFIG_CHANGE);
-      new RulesConfigurationPageSaveJob().schedule();
+
+      // INFO: This is used in integration tests as Reddeer cannot handle pop-ups displayed directly after the "Apply",
+      // "Cancel", "Apply and Close" and "Restore Defaults" buttons are pressed on configuration pages, it assumes the
+      // focus will be always on the main window afterwards! See: https://github.com/eclipse/reddeer/issues/2227
+      var delay = System.getProperty("sonarlint.internal.rulesConfigurationPageSaveJobDelay", "0");
+      new RulesConfigurationPageSaveJob().schedule(Long.parseLong(delay));
     }
     return true;
   }


### PR DESCRIPTION
Some regressions from a faulty merge introduced removed changes on the connection assistance again.
A regression from SonarQube and the SonarText was fixed (not on our side) and we are able to enable the integration test again.

Additional changes for the issues with ITs and Reddeer. The implementation of the integration tests themselves will be handled in the separate pull request linked to [this PR](https://github.com/SonarSource/sonarlint-eclipse/commit/0752033174450d8f56431671f7e7fafd27407a98) and [SLE-799](https://sonarsource.atlassian.net/browse/SLE-799).

[SLE-799]: https://sonarsource.atlassian.net/browse/SLE-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ