### PR TITLE
SLE-796: Update PyDev

### DIFF
--- a/its/target-platforms/ibuilds.target
+++ b/its/target-platforms/ibuilds.target
@@ -18,7 +18,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="http://pydev.sourceforge.net/pydev_update_site/11.0.3" />
+      <repository location="https://www.pydev.org/update_sites/12.0.0" />
     </location>
     <!-- Reddeer requires GEF legacy-->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/its/target-platforms/latest.target
+++ b/its/target-platforms/latest.target
@@ -26,7 +26,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="http://pydev.sourceforge.net/pydev_update_site/10.2.1" />
+      <repository location="https://www.pydev.org/update_sites/10.2.1" />
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />

--- a/target-platforms/build.target
+++ b/target-platforms/build.target
@@ -14,7 +14,7 @@
     <location type="Target" uri="file:${project_loc:/sonarlint-eclipse-parent}/target-platforms/commons.target"/>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="http://pydev.sourceforge.net/pydev_update_site/10.2.1" />
+      <repository location="https://www.pydev.org/update_sites/10.2.1" />
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>


### PR DESCRIPTION
## Summary

This only changes the update sites of PyDev, for iBuilds axis the version was updated to the latest release. Prior to the update of Tycho, this was flaky and it didn't support these update sites (hosted via GitHub releases).

This will also reduce the PR for using SLCORE through RPC.