### PR TITLE
Update to Tycho 4.0.6 and provision tests with p2

### DIFF
--- a/its/its-ibuilds.product
+++ b/its/its-ibuilds.product
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="A product to define the runtime of the integration tests (IBuilds)" uid="org.sonarlint.eclipse.its.ibuilds.product" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="1" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
+      </programArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <launcher name="eclipse">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.jdt"/>
+      <feature id="org.eclipse.egit"/>
+      <feature id="org.sonarlint.eclipse.feature"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
+      <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+   </configurations>
+
+</product>

--- a/its/its.product
+++ b/its/its.product
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="A product to define the runtime of the integration tests" uid="org.sonarlint.eclipse.its.product" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="1" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
+      </programArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Djava.security.manager=allow
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <launcher name="eclipse">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+   
+   <features>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.jdt"/>
+      <feature id="org.eclipse.egit"/>
+      <feature id="org.eclipse.m2e.feature"/>
+      <feature id="org.eclipse.cdt"/>
+      <feature id="org.eclipse.wst.jsdt.feature"/>
+      <feature id="org.eclipse.rse"/>
+      <feature id="org.eclipse.php"/>
+      <feature id="org.eclipse.mylyn.commons"/>
+      <feature id="org.sonarlint.eclipse.feature"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+   </configurations>
+
+</product>

--- a/its/its.product
+++ b/its/its.product
@@ -30,6 +30,7 @@
       <feature id="org.eclipse.wst.jsdt.feature"/>
       <feature id="org.eclipse.rse"/>
       <feature id="org.eclipse.php"/>
+      <feature id="org.python.pydev.feature"/>
       <feature id="org.eclipse.mylyn.commons"/>
       <feature id="org.sonarlint.eclipse.feature"/>
    </features>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -17,21 +18,22 @@
   <name>SonarLint for Eclipse Integration Tests</name>
 
   <properties>
-    <tycho.version>4.0.5</tycho.version>
+    <tycho.version>4.0.6</tycho.version>
     <license.title>SonarLint for Eclipse ITs</license.title>
     <license.mailto>sonarlint@sonarsource.com</license.mailto>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <target.platform>latest</target.platform>
     <tycho.localArtifacts>ignore</tycho.localArtifacts>
-    <!-- http://stackoverflow.com/questions/36317684/eclipse-jsdt-internal-error-noclassdeffounderror-jdk-nashorn-internal-runtime -->
+    <!--
+    http://stackoverflow.com/questions/36317684/eclipse-jsdt-internal-error-noclassdeffounderror-jdk-nashorn-internal-runtime -->
     <tycho.testArgLine>-Dorg.osgi.framework.bundle.parent=ext -Dsonarlint.telemetry.disabled=true</tycho.testArgLine>
     <sonar.runtimeVersion>LATEST_RELEASE</sonar.runtimeVersion>
     <jdk.min.version>11</jdk.min.version>
     <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
   </properties>
-  
+
   <dependencies>
-   <dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.25.1</version>
@@ -116,7 +118,7 @@
           </includes>
         </configuration>
       </plugin>
-      
+
       <!-- The environments must be in sync with Sloop embedded CLI distributions (see parent pom) -->
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
@@ -174,12 +176,13 @@
           <trimStackTrace>false</trimStackTrace>
           <useUIHarness>true</useUIHarness>
           <useUIThread>false</useUIThread>
-          <appArgLine>-eclipse.keyring target/keyring -eclipse.password secure-storage-password.txt -pluginCustomization
+          <appArgLine>-eclipse.keyring target/keyring -eclipse.password secure-storage-password.txt
+            -pluginCustomization
             ${project.basedir}/plugin_customization.ini</appArgLine>
-          
+
           <!-- Kill test JVM if tests take more than 60 minutes (3600 seconds) to finish -->
           <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
-          
+
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemProperties>
             <target.platform>${target.platform}</target.platform>
@@ -188,7 +191,22 @@
             <org.eclipse.swt.browser.DefaultType>webkit</org.eclipse.swt.browser.DefaultType>
           </systemProperties>
           <useJDK>BREE</useJDK>
+          <testRuntime>p2Installed</testRuntime>
+          <profileName>SDKProfile</profileName>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-publisher-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>publish-products-for-tests</id>
+            <goals>
+              <goal>publish-products</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -218,38 +236,25 @@
             <artifactId>tycho-surefire-plugin</artifactId>
             <configuration>
               <excludedGroups>org.sonarlint.eclipse.its.RequiresExtraDependency</excludedGroups>
-              <dependencies>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.platform.ide</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.jdt.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.sonarlint.eclipse.feature.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.egit.feature.group</artifactId>
-                </dependency>
-              </dependencies>
+              <install>
+                <iu>
+                  <id>org.sonarlint.eclipse.its.ibuilds.product</id>
+                </iu>
+              </install>
             </configuration>
           </plugin>
         </plugins>
       </build>
     </profile>
-    
+
     <!--
-    	Due to the earliest version of Eclipse for macOS on ARM64 (aarch64) being 4.22 our tests on
-    	the oldest supported version cannot be run in this environment! Therefore this profile
-    	ensures the tests will only run the oldest version with every environment but the macOS on
-    	ARM64 one.
-    	This profile can be removed in the future, when the oldest supported Eclipse version is
-    	either 4.22 or higher!
-   	-->
+      Due to the earliest version of Eclipse for macOS on ARM64 (aarch64) being 4.22 our tests on
+      the oldest supported version cannot be run in this environment! Therefore this profile
+      ensures the tests will only run the oldest version with every environment but the macOS on
+      ARM64 one.
+      This profile can be removed in the future, when the oldest supported Eclipse version is
+      either 4.22 or higher!
+     -->
     <profile>
       <id>macOS-arm64-fix-oldest</id>
       <activation>
@@ -259,37 +264,37 @@
         </property>
       </activation>
       <build>
-		<plugins>
-		  <plugin>
-	        <groupId>org.eclipse.tycho</groupId>
-	        <artifactId>target-platform-configuration</artifactId>
-	        <configuration>
-	          <target>
-	            <file>target-platforms/${target.platform}.target</file>
-	          </target>
-	          <environments>
-	            <environment>
-	              <os>win32</os>
-	              <ws>win32</ws>
-	              <arch>x86_64</arch>
-	            </environment>
-	            <environment>
-	              <os>linux</os>
-	              <ws>gtk</ws>
-	              <arch>x86_64</arch>
-	            </environment>
-	            <environment>
-	              <os>macosx</os>
-	              <ws>cocoa</ws>
-	              <arch>x86_64</arch>
-	            </environment>
-	          </environments>
-	        </configuration>
-	      </plugin>
-		</plugins>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <configuration>
+              <target>
+                <file>target-platforms/${target.platform}.target</file>
+              </target>
+              <environments>
+                <environment>
+                  <os>win32</os>
+                  <ws>win32</ws>
+                  <arch>x86_64</arch>
+                </environment>
+                <environment>
+                  <os>linux</os>
+                  <ws>gtk</ws>
+                  <arch>x86_64</arch>
+                </environment>
+                <environment>
+                  <os>macosx</os>
+                  <ws>cocoa</ws>
+                  <arch>x86_64</arch>
+                </environment>
+              </environments>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
-    
+
     <profile>
       <id>full</id>
       <activation>
@@ -306,52 +311,11 @@
             <configuration>
               <!-- Don't run SonarCloud ITs on all axis, just one (ibuilds) is enough -->
               <excludedGroups>org.sonarlint.eclipse.its.SonarCloud</excludedGroups>
-              <dependencies>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.platform.ide</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.jdt.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.sonarlint.eclipse.feature.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.m2e.feature.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.cdt.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.wst.jsdt.feature.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.rse.feature.group</artifactId>
-                </dependency>
-                <!--dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.python.pydev.feature.feature.group</artifactId>
-                </dependency-->
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.php.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.mylyn.commons.feature.group</artifactId>
-                </dependency>
-                <dependency>
-                  <type>p2-installable-unit</type>
-                  <artifactId>org.eclipse.egit.feature.group</artifactId>
-                </dependency>
-              </dependencies>
+              <install>
+                <iu>
+                  <id>org.sonarlint.eclipse.its.product</id>
+                </iu>
+              </install>
             </configuration>
           </plugin>
         </plugins>

--- a/its/target-platforms/ibuilds.target
+++ b/its/target-platforms/ibuilds.target
@@ -6,6 +6,8 @@
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0" />
       <unit id="org.eclipse.platform.ide" version="0.0.0" />
+      <!-- Needed to build the test environment -->
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/eclipse/updates/I-builds/" />
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/its/target-platforms/latest.target
+++ b/its/target-platforms/latest.target
@@ -13,6 +13,8 @@
       <unit id="org.eclipse.php.feature.group" version="0.0.0" />
       <unit id="org.eclipse.egit.feature.group" version="0.0.0" />
       <unit id="org.eclipse.pde.feature.group" version="0.0.0" />
+      <!-- Needed to build the test environment -->
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/releases/latest" />
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/its/target-platforms/oldest.target
+++ b/its/target-platforms/oldest.target
@@ -13,6 +13,8 @@
       <unit id="org.eclipse.mylyn.commons.feature.group" version="0.0.0" />
       <unit id="org.eclipse.php.feature.group" version="0.0.0" />
       <unit id="org.eclipse.egit.feature.group" version="0.0.0" />
+      <!-- Needed to build the test environment -->
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/releases/photon/" />
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.sonarlint.eclipse.core.tests/pom.xml
+++ b/org.sonarlint.eclipse.core.tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -22,40 +23,60 @@
   </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.tycho</groupId>
-          <artifactId>tycho-surefire-plugin</artifactId>
-          <configuration>
-			<trimStackTrace>false</trimStackTrace>
-            <appArgLine>-eclipse.keyring target/keyring -eclipse.password src/test/resources/secure-storage-password.txt -pluginCustomization "${project.basedir}/plugin_customization.ini"</appArgLine>
-          </configuration>
-        </plugin>
-        <plugin>
-		  <groupId>org.eclipse.tycho</groupId>
-		  <artifactId>target-platform-configuration</artifactId>
-		  <configuration>
-			<dependency-resolution>
-		      <extraRequirements>
-		        <requirement>
-		          <type>eclipse-feature</type>
-		          <id>org.sonarlint.eclipse.feature</id>
-		          <versionRange>0.0.0</versionRange>
-		        </requirement>
-		      </extraRequirements>
-		    </dependency-resolution>
-		  </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <appArgLine>-eclipse.keyring target/keyring 
+            -eclipse.password src/test/resources/secure-storage-password.txt
+            -pluginCustomization "${project.basedir}/plugin_customization.ini"</appArgLine>
+          <testRuntime>p2Installed</testRuntime>
+          <profileName>SDKProfile</profileName>
+          <install>
+            <iu>
+              <id>org.sonarlint.eclipse.tests.product</id>
+            </iu>
+          </install>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.sonarlint.eclipse.feature</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-publisher-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>publish-products-for-tests</id>
+            <goals>
+              <goal>publish-products</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
 

--- a/org.sonarlint.eclipse.core.tests/test.product
+++ b/org.sonarlint.eclipse.core.tests/test.product
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="A product to define the runtime of the tests" uid="org.sonarlint.eclipse.tests.product" id="org.eclipse.sdk.ide" application="org.eclipse.ui.ide.workbench" version="1" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>--launcher.defaultAction openFile --launcher.appendVmargs
+      </programArgs>
+      <vmArgs>-Dosgi.requiredJavaVersion=17 -Dosgi.dataAreaRequiresExplicitInit=true -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true --add-modules=ALL-SYSTEM -Dorg.slf4j.simpleLogger.defaultLogLevel=off -Djava.security.manager=allow
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <launcher name="eclipse">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+   
+   <features>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.jdt"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
+      <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="org.eclipse.update.reconcile" value="false" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
+   </configurations>
+
+</product>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <license.title>SonarLint for Eclipse</license.title>
     <license.mailto>sonarlint@sonarsource.com</license.mailto>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tycho.version>4.0.5</tycho.version>
+    <tycho.version>4.0.6</tycho.version>
     <jdk.min.version>11</jdk.min.version>
     <!-- Same protobuf version than the one in SonarLint Core-->
     <protobuf.version>3.25.1</protobuf.version>

--- a/target-platforms/build.target
+++ b/target-platforms/build.target
@@ -9,6 +9,8 @@
       <unit id="org.eclipse.platform.ide" version="0.0.0"/>
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.core.sdk.feature.group" version="0.0.0"/>
+      <!-- Needed to build the test environment -->
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/releases/2022-06/"/>
     </location>
     <location type="Target" uri="file:${project_loc:/sonarlint-eclipse-parent}/target-platforms/commons.target"/>


### PR DESCRIPTION
In order to have more "realistic" behavior of tests, we should switch to `p2Installed` mode for surefire.

This will allow to execute p2 touchpoints like a real installation.

See discussion: https://github.com/eclipse-tycho/tycho/discussions/3440