### PR TITLE
NO-JIRA: Change Slack channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
-      slackChannel: team-sonarlint-intelliclipse-notifs
+      slackChannel: squad-ide-eclipse-bots


### PR DESCRIPTION
Split the old notification channel for the IntelliClipse squad