### PR TITLE
SLE-809: Update the outgoing links to documentation

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
@@ -24,11 +24,13 @@ public class SonarLintDocumentation {
   private static final String BASE_DOCS_URL = "https://docs.sonarsource.com/sonarlint/eclipse";
   public static final String CONNECTED_MODE_LINK = BASE_DOCS_URL + "/team-features/connected-mode/";
   public static final String CONNECTED_MODE_BENEFITS = CONNECTED_MODE_LINK + "#benefits";
-  public static final String VERSION_SUPPORT_POLICY = CONNECTED_MODE_LINK + "#sonarlint-sonarqube-version-support-policy";
+  public static final String CONNECTED_MODE_SETUP_LINK = BASE_DOCS_URL + "/team-features/connected-mode-setup/";
+  public static final String VERSION_SUPPORT_POLICY = CONNECTED_MODE_SETUP_LINK + "#sonarlint-sonarqube-version-support-policy";
   public static final String BRANCH_AWARENESS = CONNECTED_MODE_LINK + "#branch-awareness";
   public static final String SECURITY_HOTSPOTS_LINK = BASE_DOCS_URL + "/using-sonarlint/security-hotspots/";
   public static final String TAINT_VULNERABILITIES_LINK = BASE_DOCS_URL + "/using-sonarlint/taint-vulnerabilities/";
   public static final String ON_THE_FLY_VIEW_LINK = BASE_DOCS_URL + "/using-sonarlint/investigating-issues/#the-on-the-fly-view";
+  public static final String ISSUE_TYPES_LINK = BASE_DOCS_URL + "/using-sonarlint/investigating-issues/#issue-types";
   public static final String REPORT_VIEW_LINK = BASE_DOCS_URL + "/using-sonarlint/investigating-issues/#the-report-view";
   public static final String ISSUE_PERIOD_LINK = BASE_DOCS_URL + "/using-sonarlint/investigating-issues/#focusing-on-new-code";
   public static final String MARK_ISSUES_LINK = BASE_DOCS_URL + "/using-sonarlint/fixing-issues/#marking-issues";
@@ -39,11 +41,11 @@ public class SonarLintDocumentation {
 
   private static final String BASE_MARKETING_URL = "https://www.sonarsource.com";
   public static final String COMPARE_SERVER_PRODUCTS_LINK = BASE_MARKETING_URL + "/open-source-editions";
-  public static final String SONARQUBE_EDITIONS_LINK = BASE_MARKETING_URL + "/open-source-editions/sonarqube-community-edition";
+  public static final String SONARQUBE_EDITIONS_LINK = COMPARE_SERVER_PRODUCTS_LINK + "/sonarqube-community-edition";
   public static final String SONARCLOUD_PRODUCT_LINK = BASE_MARKETING_URL + "/products/sonarcloud";
   public static final String SONARCLOUD_SIGNUP_LINK = SONARCLOUD_PRODUCT_LINK + "/signup";
 
-  public static final String COMMUNITY_FORUM = "https://community.sonarsource.com";
+  public static final String COMMUNITY_FORUM = "https://community.sonarsource.com/c/sl/11";
 
   private SonarLintDocumentation() {
     // utility class

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/HelpOnIconsCommand.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/command/HelpOnIconsCommand.java
@@ -21,13 +21,13 @@ package org.sonarlint.eclipse.ui.internal.command;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 
 /** When the user wants to know what the issue / rule icons mean (and why they differ between old / new CCT) */
 public class HelpOnIconsCommand extends AbstractIssueCommand {
   @Override
   protected void execute(IMarker selectedMarker, IWorkbenchWindow window) {
-    BrowserUtils.openExternalBrowser("https://docs.sonarsource.com/sonarlint/eclipse/concepts/clean-code/introduction",
-      window.getShell().getDisplay());
+    BrowserUtils.openExternalBrowser(SonarLintDocumentation.ISSUE_TYPES_LINK, window.getShell().getDisplay());
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/AbstractBindingSuggestionPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/AbstractBindingSuggestionPopup.java
@@ -37,7 +37,7 @@ public abstract class AbstractBindingSuggestionPopup extends AbstractSonarLintPo
 
   protected void addLearnMoreLink() {
     addLink("Learn more", e -> {
-      BrowserUtils.openExternalBrowser(SonarLintDocumentation.CONNECTED_MODE_LINK, e.display);
+      BrowserUtils.openExternalBrowser(SonarLintDocumentation.CONNECTED_MODE_SETUP_LINK, e.display);
       close();
     });
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SonarLintRpcClientSupportPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SonarLintRpcClientSupportPopup.java
@@ -34,9 +34,10 @@ import org.sonarlint.eclipse.ui.internal.util.PopupUtils;
 public class SonarLintRpcClientSupportPopup extends AbstractSonarLintPopup {
   @Override
   protected String getMessage() {
-    return "The RPC backend exited unexpectedly. As this should not happen, please take a look at the "
-      + "troubleshooting documentation and raise an issue on the SonarLint Community Forum. For now "
-      + "the only possibility to restart SonarLint is to restart the IDE :(";
+    return "As this should not happen, please provide us with a thread dump of the IDE process as well as a thread "
+      + "dump of the SonarLint process (can be identified by 'sloop') if available. To do that, please raise an issue "
+      + "on the Community Forum. \nWith that we can work on preventing such an issue in the future and make SonarLint "
+      + "more resiliant by recovering from this on its own! \nFor now the only possiblity is to restart the IDE :(";
   }
 
   @Override
@@ -53,7 +54,7 @@ public class SonarLintRpcClientSupportPopup extends AbstractSonarLintPopup {
 
   @Override
   protected String getPopupShellTitle() {
-    return "SonarLint - RPC backend server unavailable";
+    return "SonarLint - RPC backend server unavailable or killed";
   }
 
   @Override


### PR DESCRIPTION
The Connected Mode page was split into informational and setup pages.
Additionally, the information displayed for Sloop being killed was fixed.