### PR TITLE
SLE-781: Fix leaking Taint Vulnerabilites

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/SonarLintMarkerUpdater.java
@@ -124,8 +124,16 @@ public class SonarLintMarkerUpdater {
     for (var taintIssue : taintVulnerabilities) {
       if (!(shouldHideResolvedTaintMarker(taintIssue, issueFilterPreference)
         || shouldHidePreNewCodeTaintMarker(taintIssue, issuePeriodPreference))) {
-        findFileForLocationInBoundProjects(bindings, taintIssue.getIdeFilePath())
-          .ifPresent(primaryLocationFile -> createTaintMarker(primaryLocationFile.getDocument(), primaryLocationFile, taintIssue, bindings));
+        var optFileForTaint = findFileForLocationInBoundProjects(bindings, taintIssue.getIdeFilePath());
+        if (optFileForTaint.isEmpty()) {
+          continue;
+        }
+        var fileForTaint = optFileForTaint.get();
+        if (!fileForTaint.equals(currentFile)) {
+          continue;
+        }
+
+        createTaintMarker(fileForTaint.getDocument(), fileForTaint, taintIssue, bindings);
         actualTaintMarkersCreated = true;
       }
     }


### PR DESCRIPTION
Due to us now fetching all taints and not only the ones for the specific file, we were left with "leaked" markers when resolving / re-opening a taint.
This also led to multiple taint vulnerabilities being registered to different kinds of opened files, which was incorrect.