### PR TITLE
NO-JIRA: Don't wait for the backend

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -331,7 +331,7 @@ public class SonarLintBackendService {
       connectionSynchronizer = null;
     }
     if (backend != null) {
-      backend.shutdown().join();
+      backend.shutdown();
     }
     backend = null;
   }


### PR DESCRIPTION
It could happen randomly (mostly after running the unit tests), that the IDE froze because the SonarLint plug-in wasn't unloaded correctly. This was due to the thread waiting for Sloop to shut down - while it was already gone.