### PR TITLE
BUILD-3457 publish dogfood site on binaries

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -96,6 +96,9 @@ build_task:
     base64 --decode "${SM_CLIENT_CERT_FILE}.b64" > "${SM_CLIENT_CERT_FILE}"
     source cirrus-env BUILD-PRIVATE
     .cirrus/regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dsonar.skip=true -Dcyclonedx.skip=false
+  site_artifacts:
+    paths: org.sonarlint.eclipse.site/target/org.sonarlint.eclipse.site-*.zip
+    type: application/zip
   cleanup_before_cache_script: cleanup_maven_repository
   on_failure:
     slack_notification_script: |
@@ -289,7 +292,6 @@ promote_task:
     ARTIFACTS: org.sonarsource.sonarlint.eclipse:org.sonarlint.eclipse.site:zip,org.sonarsource.sonarlint.eclipse:sonarlint-eclipse-parent:json:cyclonedx
   <<: *SETUP_MAVEN_CACHE
   promote_script: |
-    source cirrus-env PROMOTE
     .cirrus/cirrus_promote_maven
   cleanup_before_cache_script: cleanup_maven_repository
   on_failure:
@@ -308,15 +310,14 @@ dogfood_task:
     memory: 4G
     type: m6a.large
   env:
-    ARTIFACTORY_API_USER: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter
-    ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
+    AWS_ACCESS_KEY_ID: VAULT[development/aws/sts/downloads access_key]
+    AWS_SECRET_ACCESS_KEY: VAULT[development/aws/sts/downloads secret_key]
+    AWS_SESSION_TOKEN: VAULT[development/aws/sts/downloads security_token]
+    AWS_DEFAULT_REGION: eu-central-1
   dogfood_script: |
     source cirrus-env QA
-    source .cirrus/set_maven_build_version $BUILD_NUMBER
-    jfrog rt cp \
-      sonarsource-public-builds/org/sonarsource/sonarlint/eclipse/org.sonarlint.eclipse.site/${PROJECT_VERSION}/org.sonarlint.eclipse.site-${PROJECT_VERSION}.zip \
-      sonarlint-eclipse-dogfood/org.sonarlint.eclipse.site-dogfood.zip \
-      --flat --url "${ARTIFACTORY_URL}" --access-token "${ARTIFACTORY_API_KEY}" --build "${CIRRUS_REPO_NAME}/${BUILD_NUMBER}"
+    source .cirrus/set_maven_build_version "$BUILD_NUMBER"
+    .cirrus/publish-dogfood-site.sh
   on_failure:
     slack_notification_script: |
       .cirrus/slack-notification.sh

--- a/.cirrus/publish-dogfood-site.sh
+++ b/.cirrus/publish-dogfood-site.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CIRRUS_BUILD_ID?}" "${PROJECT_VERSION?}" "${ARTIFACTORY_API_KEY?}" "${ARTIFACTORY_URL?}"
+: "${S3_BUCKET:=downloads-cdn-eu-central-1-prod}"
+: "${BINARIES_URL:=https://binaries.sonarsource.com}"
+ROOT_BUCKET_KEY="SonarLint-for-Eclipse/dogfood"
+VERSION_BUCKET_KEY="$ROOT_BUCKET_KEY/$PROJECT_VERSION"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+pushd "${SCRIPT_DIR}/" >/dev/null
+dogfood_site_dir=$(mktemp -d -p "$PWD" -t tmp.XXXXXXXX)
+trap 'rm -rf "$dogfood_site_dir" "$dogfood_site_dir".zip' EXIT
+
+curl --fail --silent --show-error --location \
+  "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/site/org.sonarlint.eclipse.site/target/org.sonarlint.eclipse.site-$PROJECT_VERSION.zip" \
+  -o "$dogfood_site_dir".zip ||
+  {
+    # local usage or any use case with no Cirrus artifact
+    type jfrog 2>/dev/null || jfrog() { jf "$@"; }
+    echo "Failed to download org.sonarlint.eclipse.site-$PROJECT_VERSION.zip from Cirrus CI build $CIRRUS_BUILD_ID; fallback on Artifactory"
+    jfrog config use repox 2>/dev/null || jfrog config add repox --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_API_KEY"
+    jfrog rt curl "sonarsource-public-builds/org/sonarsource/sonarlint/eclipse/org.sonarlint.eclipse.site/$PROJECT_VERSION/org.sonarlint.eclipse.site-$PROJECT_VERSION.zip" -o "$dogfood_site_dir".zip
+  }
+mkdir -p "$dogfood_site_dir/$PROJECT_VERSION"
+unzip -q "$dogfood_site_dir".zip -d "$dogfood_site_dir/$PROJECT_VERSION"
+
+NOW=$(date -u +"%s%3N")
+export NOW BINARIES_URL VERSION_BUCKET_KEY
+# shellcheck disable=SC2016
+envsubst '$NOW,$BINARIES_URL,$VERSION_BUCKET_KEY' <"site-resources/compositeContent.xml" >"$dogfood_site_dir/compositeContent.xml"
+# shellcheck disable=SC2016
+envsubst '$NOW,$BINARIES_URL,$VERSION_BUCKET_KEY' <"site-resources/compositeArtifacts.xml" >"$dogfood_site_dir/compositeArtifacts.xml"
+
+echo "Upload from $dogfood_site_dir to s3://$S3_BUCKET/$ROOT_BUCKET_KEY/..."
+aws s3 sync "$@" --delete "$dogfood_site_dir" "s3://$S3_BUCKET/$ROOT_BUCKET_KEY/"
+echo "Upload done"
+
+DISTRIBUTION_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[*].{id:Id,origin:Origins.Items[0].DomainName}[?starts_with(origin,'$S3_BUCKET')].id" --output text)
+aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/$ROOT_BUCKET_KEY/*"
+echo "Dogfood site published to $BINARIES_URL/?prefix=$ROOT_BUCKET_KEY/"
+popd >/dev/null

--- a/.cirrus/site-resources/compositeArtifacts.xml
+++ b/.cirrus/site-resources/compositeArtifacts.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repository name="SonarLint for Eclipse Update Site"
+            type="org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository"
+            version="1.0.0">
+  <properties size="1">
+    <property name="p2.timestamp" value="$NOW"/>
+  </properties>
+  <children size="1">
+    <child location="$BINARIES_URL/$VERSION_BUCKET_KEY"/>
+  </children>
+</repository>

--- a/.cirrus/site-resources/compositeContent.xml
+++ b/.cirrus/site-resources/compositeContent.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repository name="SonarLint for Eclipse Update Site"
+            type="org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository"
+            version="1.0.0">
+  <properties size="1">
+    <property name="p2.timestamp" value="$NOW"/>
+  </properties>
+  <children size="1">
+    <child location="$BINARIES_URL/$VERSION_BUCKET_KEY"/>
+  </children>
+</repository>


### PR DESCRIPTION
Instead of promoting the site artifact to sonarlint-eclipse-dogfood which is not publicly accessible, publish the site to https://binaries.sonarsource.com/?prefix=SonarLint-for-Eclipse/dogfood/

Manually tested with staging, see https://binaries-staging.sonarsource.com/?prefix=SonarLint-for-Eclipse/dogfood/