### PR TITLE
SLE-818: Sign ProtoBuf OSGi bundle

### DIFF
--- a/org.sonarlint.eclipse.site/pom.xml
+++ b/org.sonarlint.eclipse.site/pom.xml
@@ -70,7 +70,7 @@
           <archiveDirectory>${project.build.directory}/repository/</archiveDirectory>
           <includes>
             <include>features/*</include>
-            <include>plugins/com.google.protobuf.*</include>
+            <include>plugins/com.google.protobuf*</include>
             <include>plugins/org.sonarlint.*</include>
             <include>plugins/org.sonarsource.*</include>
           </includes>


### PR DESCRIPTION
The logic for signing ProtoBuf was incorrect and only signed the source OSGi bundle.