### PR TITLE
SLE-822: Enable users to set JRE for Sloop

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
@@ -38,6 +38,7 @@ public class SonarLintDocumentation {
   public static final String RULES = BASE_DOCS_URL + "/using-sonarlint/rules/";
   public static final String RULES_SELECTION = RULES + "#rule-selection";
   public static final String TROUBLESHOOTING_LINK = BASE_DOCS_URL + "/troubleshooting/";
+  public static final String ADVANCED_CONFIGURATION = BASE_DOCS_URL + "/team-features/advanced-configuration/";
 
   private static final String BASE_MARKETING_URL = "https://www.sonarsource.com";
   public static final String COMPARE_SERVER_PRODUCTS_LINK = BASE_MARKETING_URL + "/open-source-editions";

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -140,7 +140,8 @@ public class SonarLintBackendService {
 
           fixExecutablePermissions();
 
-          var sloop = sloopLauncher.start(sloopBasedir);
+          var java17Path = SonarLintGlobalConfiguration.getJava17Path();
+          var sloop = sloopLauncher.start(sloopBasedir, java17Path);
           sloop.onExit().thenAccept(SonarLintBackendService::onSloopExit);
           backend = sloop.getRpcServer();
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -82,6 +82,7 @@ public class SonarLintGlobalConfiguration {
   public static final String PREF_TEST_FILE_GLOB_PATTERNS_DEFAULT = ""; //$NON-NLS-1$
   public static final String PREF_SKIP_CONFIRM_ANALYZE_MULTIPLE_FILES = "skipConfirmAnalyzeMultipleFiles"; //$NON-NLS-1$
   public static final String PREF_NODEJS_PATH = "nodeJsPath"; //$NON-NLS-1$
+  public static final String PREF_JAVA17_PATH = "java17Path"; //$NON-NLS-1$
   private static final String PREF_TAINT_VULNERABILITY_DISPLAYED = "taintVulnerabilityDisplayed";
   private static final String PREF_SECRETS_EVER_DETECTED = "secretsEverDetected";
   private static final String PREF_USER_SURVEY_LAST_LINK = "userSurveyLastLink"; //$NON-NLS-1$
@@ -335,11 +336,21 @@ public class SonarLintGlobalConfiguration {
 
   @Nullable
   public static Path getNodejsPath() {
-    var nodeJsPathSetting = StringUtils.trimToNull(getPreferenceString(PREF_NODEJS_PATH));
+    return getPathFromPreference(PREF_NODEJS_PATH, "Invalid Node.js path");
+  }
+
+  @Nullable
+  public static Path getJava17Path() {
+    return getPathFromPreference(PREF_JAVA17_PATH, "Invalid Java 17+ path");
+  }
+
+  @Nullable
+  private static Path getPathFromPreference(String preference, String errorMessage) {
+    var pathSetting = StringUtils.trimToNull(getPreferenceString(preference));
     try {
-      return nodeJsPathSetting != null ? Paths.get(nodeJsPathSetting) : null;
+      return pathSetting != null ? Paths.get(pathSetting) : null;
     } catch (InvalidPathException e) {
-      SonarLintLogger.get().error("Invalid nodejs path", e);
+      SonarLintLogger.get().error(errorMessage, e);
       return null;
     }
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/FileUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/FileUtils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Locale;
 import org.sonarlint.eclipse.core.SonarLintLogger;
 
 public class FileUtils {
@@ -51,4 +52,27 @@ public class FileUtils {
     }
   }
 
+  /**
+   *  Check basic Java installation structures for macOS / Linux / Windows
+   *  -> ${value}/bin/java or ${value}/bin/java.exe
+   *  -> We do not care for macOS JDK bundles (build like a macOS application)!
+   *
+   *  @param installationDirectory where to look
+   *  @return true if executable found, false otherwise
+   */
+  public static boolean checkForJavaExecutable(Path installationDirectory) {
+    // Check basic Java installation structures for macOS / Linux / Windows
+    // -> ${value}/bin/java or ${value}/bin/java.exe
+    // -> We do not care for macOS JDK bundles (build like a macOS application)!
+    Path executable;
+
+    var osName = System.getProperty("os.name");
+    if (osName != null && osName.toLowerCase(Locale.getDefault()).startsWith("win")) {
+      executable = installationDirectory.resolve("bin/java.exe");
+    } else {
+      executable = installationDirectory.resolve("bin/java");
+    }
+
+    return Files.exists(executable);
+  }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/AbstractPathField.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/AbstractPathField.java
@@ -1,0 +1,94 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.preferences;
+
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.preference.StringButtonFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.FileDialog;
+
+/** This is used as a base for all path based preferences */
+public abstract class AbstractPathField extends StringButtonFieldEditor {
+  protected AbstractPathField(String preferenceName, String labelText, Composite parent) {
+    super(preferenceName, labelText, parent);
+    setChangeButtonText("Browse ...");
+  }
+
+  @Override
+  protected void doFillIntoGrid(Composite parent, int numColumns) {
+    super.doFillIntoGrid(parent, numColumns);
+    provideDefaultValue();
+  }
+
+  @Override
+  protected boolean doCheckState() {
+    var stringValue = getStringValue();
+    if (stringValue.isBlank()) {
+      return true;
+    }
+
+    Path path;
+    try {
+      path = Paths.get(stringValue);
+    } catch (InvalidPathException e) {
+      setErrorMessage("Invalid path: " + stringValue);
+      return false;
+    }
+    if (!Files.exists(path)) {
+      setErrorMessage("Doesn't exist: " + stringValue);
+      return false;
+    }
+    return checkStateFurther(path);
+  }
+
+  @Nullable
+  @Override
+  protected String changePressed() {
+    var dialog = new FileDialog(getShell(), SWT.OPEN);
+    if (getStringValue().trim().length() > 0) {
+      dialog.setFileName(getStringValue());
+    }
+    var file = dialog.open();
+    if (file != null) {
+      file = file.trim();
+      if (file.length() > 0) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  /** The default value should be provided for the user to see instead of a blank field */
+  abstract void provideDefaultValue();
+
+  /**
+   *  After checking if path is correct and file/folder exists, we have to do some further checks
+   *  (e.g. is there actually a Java executable present) in special occasions
+   *
+   *  @param value chosen by the user for us to test
+   *  @return true if the check succeeds, false otherwise
+   */
+  abstract boolean checkStateFurther(Path value);
+}


### PR DESCRIPTION
This will enable power users to configure SonarLint to use a specific Java 17+ JRE to run SonarLint out of process.

This is by default configured via the workspace settings but can be configured on the application level as well (not from the IDE).