### PR TITLE
BUILD-4839 Update release workflow to version 5.4.2 beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.4.2
     with:
       publishToBinaries: true
       slackChannel: squad-ide-eclipse


### PR DESCRIPTION
Updating the release workflow to 5.4.2 beta to verify the changes at https://github.com/SonarSource/gh-action_release/pull/186
