### PR TITLE
SLE-841: Telemetry on binding behaviour

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/telemetry/SonarLintTelemetry.java
@@ -110,4 +110,15 @@ public class SonarLintTelemetry {
     getTelemetryService().taintVulnerabilitiesInvestigatedLocally();
   }
 
+  public static void addedManualBindings() {
+    getTelemetryService().addedManualBindings();
+  }
+
+  public static void addedImportedBindings() {
+    getTelemetryService().addedImportedBindings();
+  }
+
+  public static void addedAutomaticBindings() {
+    getTelemetryService().addedAutomaticBindings();
+  }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/ProjectSuggestionDto.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/ProjectSuggestionDto.java
@@ -1,0 +1,41 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.binding;
+
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+
+/** Pairing the information of a project and whether its suggestion is coming from shared configuration or not */
+public class ProjectSuggestionDto {
+  private final ISonarLintProject project;
+  private final boolean isFromSharedConfiguration;
+
+  public ProjectSuggestionDto(ISonarLintProject project, boolean isFromSharedConfiguration) {
+    this.project = project;
+    this.isFromSharedConfiguration = isFromSharedConfiguration;
+  }
+
+  public ISonarLintProject getProject() {
+    return this.project;
+  }
+
+  public boolean getIsFromSharedConfiguration() {
+    return this.isFromSharedConfiguration;
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/project/ProjectBindingWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/project/ProjectBindingWizard.java
@@ -39,6 +39,7 @@ import org.sonarlint.eclipse.core.internal.backend.SonarLintBackendService;
 import org.sonarlint.eclipse.core.internal.engine.connected.ConnectionFacade;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintProjectConfiguration;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintProjectConfiguration.EclipseProjectBinding;
+import org.sonarlint.eclipse.core.internal.telemetry.SonarLintTelemetry;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.SonarLintUiPlugin;
 import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnectionWizard;
@@ -174,6 +175,15 @@ public class ProjectBindingWizard extends Wizard implements INewWizard, IPageCha
       var connectionId = connection.getId();
       getDialogSettings().put(STORE_LAST_SELECTED_CONNECTION_ID, connectionId);
       ProjectBindingProcess.bindProjects(connectionId, model.getEclipseProjects(), model.getSonarProjectKey());
+
+      // Every time a binding is created via the wizard then the binding was done manually, even if there were possible
+      // suggestions - the user just turned them down or decided otherwise! For "automatic" binding (either from normal
+      // SonarQube / SonarCloud property files found or the shared Connected Mode configurations) we always try to
+      // create the connection and binding without invoking the UI at all!
+      if (SonarLintTelemetry.isEnabled()) {
+        SonarLintTelemetry.addedManualBindings();
+      }
+
       return true;
     }
   }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/SuggestConnectionDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/SuggestConnectionDialog.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.ui.internal.binding.ProjectSuggestionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 
 /**
@@ -42,10 +42,10 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
  */
 public class SuggestConnectionDialog extends Dialog {
   private final Either<String, String> serverUrlOrOrganization;
-  private final Map<String, List<ISonarLintProject>> projectMapping;
+  private final Map<String, List<ProjectSuggestionDto>> projectMapping;
 
   public SuggestConnectionDialog(Shell parentShell, Either<String, String> serverUrlOrOrganization,
-    Map<String, List<ISonarLintProject>> projectMapping) {
+    Map<String, List<ProjectSuggestionDto>> projectMapping) {
     super(parentShell);
     this.serverUrlOrOrganization = serverUrlOrOrganization;
     this.projectMapping = projectMapping;
@@ -62,9 +62,9 @@ public class SuggestConnectionDialog extends Dialog {
     for (var entry : projectMapping.entrySet()) {
       var projectKeyTreeItem = new TreeItem(tree, SWT.NONE);
       projectKeyTreeItem.setText("Remote project '" + entry.getKey() + "'");
-      for (var project : entry.getValue()) {
+      for (var projectSuggestion : entry.getValue()) {
         var projectTreeItem = new TreeItem(projectKeyTreeItem, SWT.NONE);
-        projectTreeItem.setText("Eclipse project '" + project.getName() + "'");
+        projectTreeItem.setText("Eclipse project '" + projectSuggestion.getProject().getName() + "'");
       }
     }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SingleBindingSuggestionPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SingleBindingSuggestionPopup.java
@@ -21,6 +21,7 @@ package org.sonarlint.eclipse.ui.internal.popup;
 
 import java.util.List;
 import org.eclipse.swt.widgets.Composite;
+import org.sonarlint.eclipse.core.internal.telemetry.SonarLintTelemetry;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.binding.wizard.project.ProjectBindingProcess;
 import org.sonarlint.eclipse.ui.internal.binding.wizard.project.ProjectBindingWizard;
@@ -52,6 +53,15 @@ public class SingleBindingSuggestionPopup extends AbstractBindingSuggestionPopup
 
     addLinkWithTooltip("Bind", "Accept suggested binding", e -> {
       ProjectBindingProcess.bindProjects(bindingSuggestionDto.getConnectionId(), projectsToBind, bindingSuggestionDto.getSonarProjectKey());
+
+      if (SonarLintTelemetry.isEnabled()) {
+        if (bindingSuggestionDto.isFromSharedConfiguration()) {
+          SonarLintTelemetry.addedImportedBindings();
+        } else {
+          SonarLintTelemetry.addedAutomaticBindings();
+        }
+      }
+
       close();
     });
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SuggestConnectionPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SuggestConnectionPopup.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
-import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarlint.eclipse.ui.internal.binding.ProjectSuggestionDto;
 import org.sonarlint.eclipse.ui.internal.binding.assist.AssistSuggestConnectionJob;
 import org.sonarlint.eclipse.ui.internal.dialog.SuggestConnectionDialog;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
@@ -37,10 +37,10 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
  */
 public class SuggestConnectionPopup extends AbstractSonarLintPopup {
   private final Either<String, String> serverUrlOrOrganization;
-  private final Map<String, List<ISonarLintProject>> projectMapping;
+  private final Map<String, List<ProjectSuggestionDto>> projectMapping;
 
   public SuggestConnectionPopup(Either<String, String> serverUrlOrOrganization,
-    Map<String, List<ISonarLintProject>> projectMapping) {
+    Map<String, List<ProjectSuggestionDto>> projectMapping) {
     this.serverUrlOrOrganization = serverUrlOrOrganization;
     this.projectMapping = projectMapping;
   }
@@ -67,7 +67,7 @@ public class SuggestConnectionPopup extends AbstractSonarLintPopup {
     }
 
     return prefix + "' the project '" + projectKey
-      + "' can be connected to the local project '" + mappedProjects.get(0).getName()
+      + "' can be connected to the local project '" + mappedProjects.get(0).getProject().getName()
       + "'. Do you want to connect and bind the project?";
   }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SuggestMultipleConnectionsPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/SuggestMultipleConnectionsPopup.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarlint.eclipse.ui.internal.binding.ProjectSuggestionDto;
 import org.sonarlint.eclipse.ui.internal.binding.assist.AssistSuggestConnectionJob;
 import org.sonarlint.eclipse.ui.internal.dialog.SuggestMultipleConnectionSelectionDialog;
 import org.sonarlint.eclipse.ui.internal.dialog.SuggestMultipleConnectionsDialog;
@@ -94,6 +95,7 @@ public class SuggestMultipleConnectionsPopup extends AbstractSonarLintPopup {
       // from the dialog response we have to get back the actual connection suggestion
       var suggestion = dialog.getSuggestionFromElement(selection);
 
+      var isFromSharedConnectedMode = suggestion.isFromSharedConfiguration();
       var isSonarQube = suggestion.getConnectionSuggestion().isLeft();
       var projectKey = isSonarQube
         ? suggestion.getConnectionSuggestion().getLeft().getProjectKey()
@@ -106,8 +108,8 @@ public class SuggestMultipleConnectionsPopup extends AbstractSonarLintPopup {
         serverUrlOrOrganization = Either.forRight(suggestion.getConnectionSuggestion().getRight().getOrganization());
       }
 
-      var projectMapping = new HashMap<String, List<ISonarLintProject>>();
-      projectMapping.put(projectKey, List.of(project));
+      var projectMapping = new HashMap<String, List<ProjectSuggestionDto>>();
+      projectMapping.put(projectKey, List.of(new ProjectSuggestionDto(project, isFromSharedConnectedMode)));
 
       var job = new AssistSuggestConnectionJob(serverUrlOrOrganization, projectMapping);
       job.schedule();


### PR DESCRIPTION
## Summary

This enables us to log telemetry (if the user did not opt-out) on the binding behavior, whether the shared Connected Mode configuration was used for binding, the binding is coming from one of the SonarQube / SonarCloud properties, or the user binds projects manually.

## Testing

Telemetry is always disabled for unit/integration tests.