### PR TITLE
BUILD-4839 Update release workflow to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.5.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
       slackChannel: squad-ide-eclipse


### PR DESCRIPTION
Release Action version 5.5.0 has been published. Update the release workflow to use the v5 branch for future updates. More details are at https://github.com/SonarSource/gh-action_release/releases.