### PR TITLE
SLE-854: Fix JDT with COBOL

### DIFF
--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -80,7 +80,13 @@ public class JdtUtils {
       var fileExtensions = javaContentType.getFileSpecs(IContentType.FILE_EXTENSION_SPEC);
       return List.of(fileExtensions).contains(file.getFileExtension());
     }
-    return !javaElt.getJavaProject().isOnClasspath(javaElt) || !isStructureKnown(javaElt);
+
+    // SLE-854 When a supposed Java file was found, we also have to check if it is a Java project. When not a Java
+    // project, we shouldn't exclude files just because there is no JavaProject and no classpath configured correctly.
+    // The file might have been flagged as Java because `JavaCore.getJavaLikeExtensions()` tried to categorize the file
+    // by accident!
+    return hasJavaNature(file.getProject())
+      && (!javaElt.getJavaProject().isOnClasspath(javaElt) || !isStructureKnown(javaElt));
   }
 
   private static boolean isStructureKnown(IJavaElement javaElt) {


### PR DESCRIPTION
When having the Java Development Tools (JDT) installed but working with COBOL files with non-Java projects, we have to make sure JDT does not try to see it as a 'Java-like' file due to the extension (e.g., `cbl`). Otherwise, it would try to exclude it from the analysis because it is not in the Java classpath and, therefore, not compiled.

JDT itself tries to find 'Java-like' file extensions by the standard Java file suffixes and from other ones it seems. I've created an [issue](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2389) with Eclipse JDT just in case this is actually a bug.