### PR TITLE
SLE-793: Dependency simplification

### DIFF
--- a/org.sonarlint.eclipse.core.tests/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.core.tests/META-INF/MANIFEST.MF
@@ -22,9 +22,5 @@ Require-Bundle: org.eclipse.core.resources,
  assertj-core,
  org.objenesis,
  net.bytebuddy.byte-buddy,
- com.google.protobuf;bundle-version="3.25.1",
- org.sonarsource.sonarlint.core.sonarlint-rpc-protocol,
- org.sonarsource.sonarlint.core.sonarlint-rpc-java-client,
- org.sonarsource.sonarlint.core.sonarlint-java-client-utils,
- org.sonarsource.sonarlint.core.sonarlint-java-client-legacy
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
@@ -41,16 +41,10 @@ Require-Bundle: org.eclipse.equinox.security,
  org.eclipse.core.filesystem,
  org.eclipse.team.core,
  org.eclipse.jdt.annotation;resolution:=optional,
- com.google.gson;bundle-version="2.10.1",
  org.eclipse.jgit;resolution:=optional,
  org.eclipse.egit.core;resolution:=optional,
  org.eclipse.egit.ui;resolution:=optional,
  org.eclipse.text,
- org.eclipse.lsp4j.jsonrpc,
- com.google.protobuf;bundle-version="3.25.1",
- org.sonarsource.sonarlint.core.sonarlint-rpc-protocol;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-rpc-java-client;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-java-client-utils;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-java-client-legacy;bundle-version="[10.2.0,10.3.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.2.0,10.3.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -19,10 +19,6 @@
  */
 package org.sonarlint.eclipse.core.internal.preferences;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,6 +56,10 @@ import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.DidChangeClientNodeJsPathParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.StandaloneRuleConfigDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.UpdateStandaloneRulesConfigurationParams;
+import org.sonarsource.sonarlint.shaded.com.google.gson.Gson;
+import org.sonarsource.sonarlint.shaded.com.google.gson.JsonParseException;
+import org.sonarsource.sonarlint.shaded.com.google.gson.annotations.SerializedName;
+import org.sonarsource.sonarlint.shaded.com.google.gson.reflect.TypeToken;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;

--- a/org.sonarlint.eclipse.feature/feature.xml
+++ b/org.sonarlint.eclipse.feature/feature.xml
@@ -102,31 +102,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.sonarsource.sonarlint.core.sonarlint-rpc-protocol"
+         id="org.sonarsource.sonarlint.core.sonarlint-java-client-osgi"
          version="0.0.0"/>
-
-   <plugin
-         id="org.sonarsource.sonarlint.core.sonarlint-rpc-java-client"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.sonarsource.sonarlint.core.sonarlint-java-client-utils"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.sonarsource.sonarlint.core.sonarlint-java-client-legacy"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.lsp4j.jsonrpc"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.google.gson"
-         version="0.0.0"/>
-
-   <plugin
-         id="com.google.protobuf"
-         version="0.0.0"/>
-
 </feature>

--- a/org.sonarlint.eclipse.site/pom.xml
+++ b/org.sonarlint.eclipse.site/pom.xml
@@ -70,7 +70,6 @@
           <archiveDirectory>${project.build.directory}/repository/</archiveDirectory>
           <includes>
             <include>features/*</include>
-            <include>plugins/com.google.protobuf*</include>
             <include>plugins/org.sonarlint.*</include>
             <include>plugins/org.sonarsource.*</include>
           </includes>

--- a/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
@@ -25,12 +25,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.team.core,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.text,
- org.eclipse.lsp4j.jsonrpc;bundle-version="0.22.0",
  org.eclipse.core.expressions,
- org.sonarsource.sonarlint.core.sonarlint-rpc-protocol;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-rpc-java-client;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-java-client-utils;bundle-version="[10.2.0,10.3.0)",
- org.sonarsource.sonarlint.core.sonarlint-java-client-legacy;bundle-version="[10.2.0,10.3.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.2.0,10.3.0)"
 Export-Package: org.sonarlint.eclipse.ui.internal;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.backend;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.notifications;x-friends:="org.sonarlint.eclipse.core.tests",

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <jarsigner.version>3.0.0</jarsigner.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>10.2.0.77758</sloop.version>
+    <sloop.version>10.2.0.77860</sloop.version>
 
     <!-- ================== -->
     <!-- For SonarQube analysis -->

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -6,41 +6,12 @@
       <unit id="org.slf4j.api" version="0.0.0"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
     </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.22.0/"/>
-	  <unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
-    </location>
 	  <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		  <dependencies>
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
-                  <artifactId>sonarlint-rpc-protocol</artifactId>
-				  <version>10.2.0.77758</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.sonarsource.sonarlint.core</groupId>
-                  <artifactId>sonarlint-rpc-java-client</artifactId>
-				  <version>10.2.0.77758</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.sonarsource.sonarlint.core</groupId>
-                  <artifactId>sonarlint-java-client-utils</artifactId>
-				  <version>10.2.0.77758</version>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>org.sonarsource.sonarlint.core</groupId>
-                  <artifactId>sonarlint-java-client-legacy</artifactId>
-				  <version>10.2.0.77758</version>
-                  <classifier>osgi</classifier>
-				  <type>jar</type>
-			  </dependency>
-			  <dependency>
-				  <groupId>com.google.protobuf</groupId>
-                  <artifactId>protobuf-java</artifactId>
-				  <version>3.25.1</version>
+                  <artifactId>sonarlint-java-client-osgi</artifactId>
+				  <version>10.2.0.77860</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
## Summay

In order to fix issues of leaking packages that created conflicts with other Eclipse plug-ins/bundles, the new dependencies on SLCORE are once again shaded/relocated into a single OSGi bundle. The main changes are done on SLCORE; on SLE, there is only relying on the relocated GSON.

The bundle `sonarlint-java-client-osgi` contains the other SLCORE modules as well as the dependencies *LSP4J*, *GSON*, and *ProtoBuf*. This mimics the pre-Sloop logic of having the `sonarlint-core-osgi` bundle.

## Testing

Integration tests running successfully, manually tested different Eclipse installation and plug-in combinations. Testing with COBOL-IDEs will be done on their side, already reached out.