### PR TITLE
Avoid resourceChanged computation for IncrementalProjectBuilder.CLEAN_BUILD in FileSystemSynchronizer

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
@@ -32,6 +32,7 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -69,6 +70,9 @@ public class FileSystemSynchronizer implements IResourceChangeListener {
 
   @Override
   public void resourceChanged(IResourceChangeEvent event) {
+    if (event.getBuildKind() == IncrementalProjectBuilder.CLEAN_BUILD) {
+      return;
+    }
     var changedOrAddedFiles = new ArrayList<ISonarLintFile>();
     var removedFiles = new ArrayList<URI>();
     try {


### PR DESCRIPTION
As mentionned in the IncrementalProjectBuilder.CLEAN_BUILD documentation 'Resource deltas are not applicable for this kind of build.'
This is a performance optimisation. I did noticed that when i was doing a "Maven update" is was way longer when SonarLint is enabled. It was because the FileSystemSynchronizer #resourceChanged was doing a lot of computation.
It's the same issue than https://github.com/SonarSource/sonarlint-eclipse/pull/539