### PR TITLE
SLE-793: Use simplified SLCORE artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ target/
 *.iml
 .idea/
 
+# VScode
+.vscode/
+
 # build products
 org.sonarlint.eclipse.core/plugins/
 org.sonarlint.eclipse.core/lib/

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <jarsigner.version>3.0.0</jarsigner.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>10.2.0.77860</sloop.version>
+    <sloop.version>10.2.0.77908</sloop.version>
 
     <!-- ================== -->
     <!-- For SonarQube analysis -->

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -11,7 +11,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
                   <artifactId>sonarlint-java-client-osgi</artifactId>
-				  <version>10.2.0.77860</version>
+				  <version>10.2.0.77908</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
This uses the simplified artifact from https://github.com/SonarSource/sonarlint-core/pull/970. The simplification in the OSGI bundle should have no impact.