### PR TITLE
SLE-851: Handle simple and complex timeout configuration

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.core.internal.utils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.sonarlint.eclipse.core.SonarLintLogger;
+import org.sonarlint.eclipse.core.internal.LogListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DurationUtilsTest {
+  private static final String PROPERTY_NULL = "PROPERTY_NULL";
+  private static final String PROPERTY_MINUTES = "PROPERTY_MINUTES";
+  private static final String PROPERTY_COMPLEX = "PROPERTY_COMPLEX";
+  private static final String PROPERTY_FAILURE = "PROPERTY_FAILURE";
+
+  private static final List<String> errors = new ArrayList<>();
+
+  @BeforeClass
+  public static void setSystemProperties() {
+    System.setProperty(PROPERTY_MINUTES, "4");
+    System.setProperty(PROPERTY_COMPLEX, "PT3H");
+    System.setProperty(PROPERTY_FAILURE, "bamboozled");
+
+    SonarLintLogger.get().addLogListener(new LogListener() {
+      @Override
+      public void info(@Nullable String msg, boolean fromAnalyzer) {
+      }
+
+      @Override
+      public void error(@Nullable String msg, boolean fromAnalyzer) {
+        errors.add(msg);
+      }
+
+      @Override
+      public void debug(@Nullable String msg, boolean fromAnalyzer) {
+      }
+    });
+  }
+
+  @AfterClass
+  public static void removeSystemProperties() {
+    System.clearProperty(PROPERTY_NULL);
+    System.clearProperty(PROPERTY_MINUTES);
+    System.clearProperty(PROPERTY_COMPLEX);
+    System.clearProperty(PROPERTY_FAILURE);
+  }
+
+  @Test
+  public void test_getTimeoutProperty_null() {
+    assertThat(DurationUtils.getTimeoutProperty(PROPERTY_NULL))
+      .isNull();
+  }
+
+  @Test
+  public void test_getTimeoutProperty_simple() {
+    assertThat(DurationUtils.getTimeoutProperty(PROPERTY_MINUTES))
+      .isEqualTo(Duration.ofMinutes(4));
+  }
+
+  @Test
+  public void test_getTimeoutProperty_complex() {
+    assertThat(DurationUtils.getTimeoutProperty(PROPERTY_COMPLEX))
+      .isEqualTo(Duration.ofHours(3));
+  }
+
+  @Test()
+  public void test_getTimeoutProperty_fails() {
+    assertThat(DurationUtils.getTimeoutProperty(PROPERTY_FAILURE))
+      .isNull();
+    assertThat(errors)
+      .contains("Timeout of system property '" + PROPERTY_FAILURE + "' cannot be parsed!");
+  }
+}

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -52,6 +51,7 @@ import org.sonarlint.eclipse.core.internal.StoragePathManager;
 import org.sonarlint.eclipse.core.internal.engine.connected.ConnectionFacade;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.telemetry.SonarLintTelemetry;
+import org.sonarlint.eclipse.core.internal.utils.DurationUtils;
 import org.sonarlint.eclipse.core.internal.utils.JavaRuntimeUtils;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
 import org.sonarlint.eclipse.core.internal.vcs.VcsService;
@@ -246,11 +246,16 @@ public class SonarLintBackendService {
 
   private static HttpConfigurationDto getHttpConfiguration() {
     return new HttpConfigurationDto(
-      new SslConfigurationDto(getPathProperty("sonarlint.ssl.trustStorePath"), System.getProperty("sonarlint.ssl.trustStorePassword"),
-        System.getProperty("sonarlint.ssl.trustStoreType"), getPathProperty("sonarlint.ssl.keyStorePath"), System.getProperty("sonarlint.ssl.keyStorePassword"),
+      new SslConfigurationDto(getPathProperty("sonarlint.ssl.trustStorePath"),
+        System.getProperty("sonarlint.ssl.trustStorePassword"),
+        System.getProperty("sonarlint.ssl.trustStoreType"),
+        getPathProperty("sonarlint.ssl.keyStorePath"),
+        System.getProperty("sonarlint.ssl.keyStorePassword"),
         System.getProperty("sonarlint.ssl.keyStoreType")),
-      getTimeoutProperty("sonarlint.http.connectTimeout"), getTimeoutProperty("sonarlint.http.socketTimeout"), getTimeoutProperty("sonarlint.http.connectionRequestTimeout"),
-      getTimeoutProperty("sonarlint.http.responseTimeout"));
+      DurationUtils.getTimeoutProperty("sonarlint.http.connectTimeout"),
+      DurationUtils.getTimeoutProperty("sonarlint.http.socketTimeout"),
+      DurationUtils.getTimeoutProperty("sonarlint.http.connectionRequestTimeout"),
+      DurationUtils.getTimeoutProperty("sonarlint.http.responseTimeout"));
   }
 
   @Nullable
@@ -267,12 +272,6 @@ public class SonarLintBackendService {
   private static Path getPathProperty(String propertyName) {
     var property = System.getProperty(propertyName);
     return property == null ? null : Paths.get(property);
-  }
-
-  @Nullable
-  private static Duration getTimeoutProperty(String propertyName) {
-    var property = System.getProperty(propertyName);
-    return property == null ? null : Duration.parse(property);
   }
 
   private static void onSloopExit(int exitCode) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/DurationUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/DurationUtils.java
@@ -1,0 +1,55 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.core.internal.utils;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import org.eclipse.jdt.annotation.Nullable;
+import org.sonarlint.eclipse.core.SonarLintLogger;
+
+public class DurationUtils {
+  private DurationUtils() {
+    // utility class
+  }
+
+  /**
+   *  Users can provide properties containing simple timeouts ("3" is "3 minutes") or more complex ones ("PT4H" is
+   *  "4 hours"). We have to check all the different cases for users who configure the timeouts differently.
+   */
+  @Nullable
+  public static Duration getTimeoutProperty(String propertyName) {
+    var property = System.getProperty(propertyName);
+    if (property == null) {
+      return null;
+    }
+
+    try {
+      return Duration.ofMinutes(Integer.parseInt(property));
+    } catch (NumberFormatException ignored) {
+    }
+
+    try {
+      return Duration.parse(property);
+    } catch (DateTimeParseException err) {
+      SonarLintLogger.get().error("Timeout of system property '" + propertyName + "' cannot be parsed!", err);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
With that SonarLint can now handle simple (like "3" for "3 minutes") and complex (like "PT4H" for "4 hours") timeout configurations again.