### PR TITLE
NO-JIRA: Use latest SLCORE

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintEclipseHeadlessRpcClient.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintEclipseHeadlessRpcClient.java
@@ -199,7 +199,7 @@ public abstract class SonarLintEclipseHeadlessRpcClient implements SonarLintRpcC
   }
 
   @Override
-  public void didDetectSecret() {
+  public void didDetectSecret(String configScopeId) {
     SonarLintNotifications.get().showNotificationIfFirstSecretDetected();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <jarsigner.version>3.0.0</jarsigner.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>10.2.0.77908</sloop.version>
+    <sloop.version>10.2.0.77993</sloop.version>
 
     <!-- ================== -->
     <!-- For SonarQube analysis -->

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -11,7 +11,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
                   <artifactId>sonarlint-java-client-osgi</artifactId>
-				  <version>10.2.0.77908</version>
+				  <version>10.2.0.77993</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
We currently rely on a PR artifact that will soon be gone.

For the changes on `SonarLintRpcClientDelegate#didDetectSecret(...)` the following ticket was created to be tackled in the future: [SLE-867: Secrets detected notification based on project](https://sonarsource.atlassian.net/browse/SLE-867)