### PR TITLE
NO-JIRA: Upload correct logs on unit tests

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -141,7 +141,9 @@ validate_task:
     /etc/init.d/xvfb stop
   cleanup_before_cache_script: cleanup_maven_repository
   on_failure:
-    mvn_log_artifacts:
+    mvn_startTestLog_artifacts:
+      path: "${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/work/configuration/*.log"
+    mvn_runTestLog_artifacts:
       path: "${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/work/data/.metadata/.log"
     xvfb_log_artifacts:
       path: "${CIRRUS_WORKING_DIR}/Xvfb.out"
@@ -208,8 +210,6 @@ qa_task:
       /etc/init.d/xvfb stop
     test_recording_artifacts:
       path: "${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4"
-    log_artifacts:
-      path: "its/build/idea-sandbox/system/log"
     jacoco_artifacts:
       path: "${CIRRUS_WORKING_DIR}/it-coverage*.exec"
   on_failure:

--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -230,8 +230,8 @@ inspect_orchestrator_cache_task:
   depends_on: qa
   eks_container:
     <<: *CONTAINER_DEFINITION
-    cpu: 1
-    memory: 1G
+    cpu: 4
+    memory: 8G
   <<: *SETUP_ORCHESTRATOR_CACHE
   inspect_cache_script: |
     echo "Inspecting cache ${ORCHESTRATOR_HOME}..."

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -113,8 +113,6 @@ qa_ibuilds_task:
       /etc/init.d/xvfb stop
     test_recording_artifacts:
       path: "${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4"
-    log_artifacts:
-      path: "its/build/idea-sandbox/system/log"
   on_failure:
     xvfb_log_artifacts:
       path: "${CIRRUS_WORKING_DIR}/Xvfb.out"

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -132,8 +132,8 @@ inspect_orchestrator_cache_task:
   depends_on: qa_ibuilds
   eks_container:
     <<: *CONTAINER_DEFINITION
-    cpu: 1
-    memory: 1G
+    cpu: 4
+    memory: 8G
   <<: *SETUP_ORCHESTRATOR_CACHE
   inspect_cache_script: |
     echo "Inspecting cache ${ORCHESTRATOR_HOME}..."


### PR DESCRIPTION
For unit tests, we need to upload not only the logs produced when running the tests but also the ones from Maven / Tycho produced while starting the *Junit Plug-In Tests* (the headless Eclipse instance that needs to be started in order to load the SonarLint plug-ins).

Also, don't fail/hang on logs that are not available on integration tests for SLE (the line was copied from IntelliJ by mistake).