### PR TITLE
SLE-881: Change copyright year to 2024

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarLint for Eclipse
-Copyright (C) 2015-2023 SonarSource SA
+Copyright (C) 2015-2024 SonarSource SA
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ our own plugins.
 
 ### License
 
-Copyright 2015-2023 SonarSource.
+Copyright 2015-2024 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/org.sonarlint.eclipse.feature/feature.properties
+++ b/org.sonarlint.eclipse.feature/feature.properties
@@ -5,7 +5,7 @@ description=\
 SonarLint is an IDE extension that helps you detect and fix quality issues as you write code.
 
 copyright=\
-Copyright 2015-2023 SonarSource S.A, Switzerland.
+Copyright 2015-2024 SonarSource S.A, Switzerland.
 
 license=\
 Licensed under the GNU Lesser General Public License, Version 3.0\n\

--- a/org.sonarlint.eclipse.ui/about.properties
+++ b/org.sonarlint.eclipse.ui/about.properties
@@ -2,7 +2,7 @@ featureName=SonarLint for Eclipse
 featureText=SonarLint for Eclipse\n\
  \n\
  SonarLint is an IDE extension that helps you detect and fix quality issues as you write code.\n\
- Copyright 2015-2023 SonarSource S.A, Switzerland.\n\
+ Copyright 2015-2024 SonarSource S.A, Switzerland.\n\
  Licensed under the GNU Lesser General Public License, Version 3.0\n\
  \n\
  Visit https://docs.sonarsource.com/sonarlint/eclipse/license/\n\


### PR DESCRIPTION
These ones were missed when updating the license headers at the beginning of 2024.