### PR TITLE
SLE-877: Correctly handle updates to Taint Vulnerabilities

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
@@ -332,8 +332,14 @@ public class SonarLintEclipseRpcClient extends SonarLintEclipseHeadlessRpcClient
     var project = projectOpt.get();
     var bindingOpt = SonarLintCorePlugin.getConnectionManager().resolveBinding(project);
     if (bindingOpt.isPresent()) {
+      // INFO: It can be that there is no file of that project currently opened, in that case return directly!
       var openedFiles = PlatformUtils.collectOpenedFiles(project, f -> true);
-      var files = openedFiles.get(project).stream()
+      var projectFiles = openedFiles.get(project);
+      if (projectFiles == null || projectFiles.isEmpty()) {
+        return;
+      }
+
+      var files = projectFiles.stream()
         .map(file -> file.getFile())
         .collect(Collectors.toList());
 


### PR DESCRIPTION
When Taint Vulnerabilities were updated but no file containing one is currently opened, then we don't have to update the markers and shouldn't assume there are opened files.