### PR TITLE
SLE-886: Use latest SLCORE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jarsigner.version>3.0.0</jarsigner.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>10.3.0.78220</sloop.version>
+    <sloop.version>10.3.0.78313</sloop.version>
 
     <!-- ================== -->
     <!-- For SonarQube analysis -->

--- a/target-platforms/commons.target
+++ b/target-platforms/commons.target
@@ -11,7 +11,7 @@
 			  <dependency>
 				  <groupId>org.sonarsource.sonarlint.core</groupId>
                   <artifactId>sonarlint-java-client-osgi</artifactId>
-				  <version>10.3.0.78220</version>
+				  <version>10.3.0.78313</version>
 				  <type>jar</type>
 			  </dependency>
 		  </dependencies>


### PR DESCRIPTION
The latest SLCORE version contains a fix to the translation of Windows file paths provided to the git-files-blame library.