### PR TITLE
SLE-868: Fix rule description parts containing links

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SonarLintWebView.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SonarLintWebView.java
@@ -131,7 +131,10 @@ public class SonarLintWebView extends Composite implements Listener, IPropertyCh
       browser.addProgressListener(ProgressListener.completedAdapter(event -> {
         updateBrowserHeightHint(browserLayoutData);
       }));
-      // This is to avoid the browser to capture mouse wheel events, and so preventing to scroll the parent scrollable
+
+      // This is to avoid the browser to capture mouse wheel events, and so preventing to scroll the parent scrollable.
+      // In case the browser contains links (a elements with href), we don't disable it for the user to still make use
+      // of the link, see "reload()" method down below!
       browser.setCapture(false);
       browser.setEnabled(false);
     } catch (SWTError e) {
@@ -282,6 +285,14 @@ public class SonarLintWebView extends Composite implements Listener, IPropertyCh
   }
 
   private void reload() {
+    // Enable the browser element to be clicked so links can be followed. As a rule description is made up of different
+    // browser instances, this will only impact the single one.
+    if (htmlBody.contains("href=\"http")) {
+      browser.setEnabled(true);
+    } else {
+      browser.setEnabled(false);
+    }
+
     browser.setText("<!doctype html><html><head>" + css() + "</head><body>" + htmlBody + "</body></html>");
     browser.requestLayout();
   }


### PR DESCRIPTION
# Summary

Some time ago, we changed the SWT browser instances used inside the **Rule Description** view to always be disabled to render properly and not display different scrollbars (as this is a nested element). With this, now, the behavior is the same, but for small browser instances containing links (really small ones), it is enabled to click them; the browsers won't have scrollbars, and so on because they're so small.

# Testing

Open any rule either on the **Rule Description** view or in the SonarLint Rule preferences that contain links, e.g. `php:S1780`, and navigate to the *More Info* tab. Now the links are clickable again.