### PR TITLE
SLE-806: Only support SonarQube 9.9 and newer

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -172,16 +172,20 @@ qa_task:
   matrix:
     - env:
         TARGET_PLATFORM: 'oldest'
-        SQ_VERSION: 'LATEST_RELEASE[8.9]'
-        QA_CATEGORY: 'Oldest'
+        SQ_VERSION: 'LATEST_RELEASE[9.9]'
+        QA_CATEGORY: 'oldest-LATEST_RELEASE_99'
     - env:
         TARGET_PLATFORM: 'latest'
         SQ_VERSION: 'LATEST_RELEASE[9.9]'
-        QA_CATEGORY: 'Latest-LTS'
+        QA_CATEGORY: 'latest-LATEST_RELEASE_99'
+    - env:
+        TARGET_PLATFORM: 'latest'
+        SQ_VERSION: 'LATEST_RELEASE'
+        QA_CATEGORY: 'latest-LATEST_RELEASE'
     - env:
         TARGET_PLATFORM: 'latest'
         SQ_VERSION: 'DEV'
-        QA_CATEGORY: 'Latest'
+        QA_CATEGORY: 'latest-DEV'
   <<: *SETUP_MAVEN_CACHE_QA
   <<: *SETUP_ORCHESTRATOR_CACHE
   download_staged_update_site_script: |
@@ -198,15 +202,9 @@ qa_task:
     ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4
   run_its_script: |
     echo "Run Maven ITs for Eclipse ${TARGET_PLATFORM} and Server ${SQ_VERSION}"
-
-    ORCHESTRATOR_CONFIG="-Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator.properties"
-    if [[ "${TARGET_PLATFORM}" == "oldest" ]]; then
-      ORCHESTRATOR_CONFIG="-Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator-oldest.properties"
-    fi
-
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify -f its/pom.xml -Pcoverage \
       -Dtarget.platform=${TARGET_PLATFORM} -Dtycho.localArtifacts=ignore -Dsonarlint-eclipse.p2.url="file://${CIRRUS_WORKING_DIR}/staged-repository" -Dsonar.runtimeVersion=${SQ_VERSION} \
-      -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/it-coverage.exec $ORCHESTRATOR_CONFIG
+      -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/it-coverage.exec
     mv it-coverage.exec it-coverage-${QA_CATEGORY}.exec
   cleanup_before_cache_script: cleanup_maven_repository
   always:

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -90,8 +90,7 @@ qa_ibuilds_task:
     mvn -B -e -V verify -f its/pom.xml \
       -Dtarget.platform=ibuilds -Dtycho.localArtifacts=ignore \
       -Dsonarlint-eclipse.p2.url="file://${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.site/target/repository" \
-      -Dsonar.runtimeVersion="LATEST_RELEASE[9.9]" \
-      -Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator.properties
+      -Dsonar.runtimeVersion="LATEST_RELEASE[9.9]"
   cleanup_before_cache_script: cleanup_maven_repository
   always:
     stop_recording_script: |

--- a/its/orchestrator-oldest.properties
+++ b/its/orchestrator-oldest.properties
@@ -1,6 +1,0 @@
-# Currently the oldest target platform is still running with Eclipse IDE based on Java 11 and
-# against SonarQube 8.9 LTS! Once support for SonarQube < 9.9 LTS is dropped, this can be removed
-# since then even the oldest supported SonarQube version (9.9 LTS) will require Java 17 to run.
-#
-# -> Also drop the changes in ".cirrus.default.yml"!
-java.home=/opt/java/openjdk-11

--- a/its/orchestrator.properties
+++ b/its/orchestrator.properties
@@ -1,4 +1,0 @@
-# Currently the "iBuilds" target platform is running with Eclipse IDE based on Java 21 and against
-# SonarQube 9.9 LTS that is only compatible with Java 17! The latest target platform is already
-# running with Java 17.
-java.home=/opt/java/openjdk

--- a/its/src/org/sonarlint/eclipse/its/AbstractSonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/AbstractSonarQubeConnectedModeTest.java
@@ -133,11 +133,7 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
 
     connectionNamePage.setConnectionName("test");
     wizard.next();
-
-    if (orchestrator.getServer().version().isGreaterThanOrEquals(8, 7)) {
-      // SONAR-14306 Starting from 8.7, dev notifications are available even in community edition
-      wizard.next();
-    }
+    wizard.next();
     wizard.finish();
 
     new WaitWhile(new JobIsRunning(), TimePeriod.LONG);

--- a/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
@@ -284,7 +284,9 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
         defaultEditor.save();
       });
 
-      assertThat(defaultEditor.getMarkers()).isEmpty();
+      assertThat(defaultEditor.getMarkers())
+        .filteredOn(marker -> marker.getType().equals("org.sonarlint.eclipse.onTheFlyIssueAnnotationType"))
+        .isEmpty();
     });
   }
 

--- a/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
+++ b/its/src/org/sonarlint/eclipse/its/SonarQubeConnectedModeTest.java
@@ -242,8 +242,6 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
 
   @Test
   public void shouldAutomaticallyUpdateRuleSetWhenChangedOnServer() throws Exception {
-    Assume.assumeTrue(orchestrator.getServer().version().isGreaterThanOrEquals(9, 4));
-
     new JavaPerspective().open();
     var rootProject = importExistingProjectIntoWorkspace("java/java-simple", JAVA_SIMPLE_PROJECT_KEY);
 
@@ -261,8 +259,11 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
     // INFO: This is a corner case where we cannot use AbstractSonarLintTest#waitForMarkers!
     var defaultEditor = new TextEditor();
     await().untilAsserted(() -> {
-      assertThat(defaultEditor.getMarkers()).hasSize(1);
       assertThat(defaultEditor.getMarkers())
+        .filteredOn(marker -> marker.getType().equals("org.sonarlint.eclipse.onTheFlyIssueAnnotationType"))
+        .hasSize(1);
+      assertThat(defaultEditor.getMarkers())
+        .filteredOn(marker -> marker.getType().equals("org.sonarlint.eclipse.onTheFlyIssueAnnotationType"))
         .satisfiesAnyOf(
           list -> assertThat(list)
             .extracting(Marker::getText, Marker::getLineNumber)
@@ -531,7 +532,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
   private static void deactivateRule(QualityProfile qualityProfile, String ruleKey) {
     var request = new PostRequest("/api/qualityprofiles/deactivate_rule")
       .setParam("key", qualityProfile.getKey())
-      .setParam("rule", javaRuleKey(ruleKey));
+      .setParam("rule", "java:" + ruleKey);
     try (var response = adminWsClient.wsConnector().call(request)) {
       assertTrue("Unable to deactivate rule " + ruleKey, response.isSuccessful());
     }
@@ -540,15 +541,10 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
   private static void activateRule(QualityProfile qualityProfile, String ruleKey) {
     var request = new PostRequest("/api/qualityprofiles/activate_rule")
       .setParam("key", qualityProfile.getKey())
-      .setParam("rule", javaRuleKey(ruleKey));
+      .setParam("rule", "java:" + ruleKey);
     try (var response = adminWsClient.wsConnector().call(request)) {
       assertTrue("Unable to activate rule " + ruleKey, response.isSuccessful());
     }
-  }
-
-  private static String javaRuleKey(String key) {
-    // Starting from SonarJava 6.0 (embedded in SQ 8.2), rule repository has been changed
-    return orchestrator.getServer().version().isGreaterThanOrEquals(8, 2) ? ("java:" + key) : ("squid:" + key);
   }
 
   private static void setNewCodePeriodToPreviousVersion(String projectKey) {

--- a/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
+++ b/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
@@ -236,12 +236,12 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
     helloJavaFile.open();
 
     var textEditor = new TextEditor();
-    assertThat(textEditor.getMarkers()).isEmpty();
+    waitForNoMarkers(textEditor);
 
     textEditor.insertText(8, 29, "2");
     textEditor.save();
 
-    assertThat(textEditor.getMarkers()).isEmpty();
+    waitForNoMarkers(textEditor);
 
     assertThat(scheduledAnalysisJobCount.get()).isEqualTo(analysisJobCountBefore);
 

--- a/its/target-platforms/oldest.target
+++ b/its/target-platforms/oldest.target
@@ -26,5 +26,5 @@
       <repository location="https://www.pydev.org/update_sites/6.0.0/" />
     </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11" />
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />
 </target>


### PR DESCRIPTION
SonarQube 9.9 is the latest active, long-term version; SonarLint will only support this and all newer versions. The changes will be merged after they are made in SLCORE.