### PR TITLE
SLE-888: Split debug logs and IDE-specific traces

### DIFF
--- a/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
+++ b/its/src/org/sonarlint/eclipse/its/StandaloneAnalysisTest.java
@@ -137,17 +137,25 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
   /** See SLE-854: JDT tries to find files with 'Java-like' extensions even if they're not Java */
   @Test
   public void test_jdt_java_like_extension_COBOL() {
-    new JavaPerspective().open();
-    var rootProject = importExistingProjectIntoWorkspace("connected", "connected");
+    // INFO: Here we check for the IDE-specific logs, so we have to enable them!
+    var consoleView = new SonarLintConsole();
+    try {
+      consoleView.enableIdeSpecificLogs(true);
 
-    var cobolFile = rootProject.getResource("Test.cbl");
-    openFileAndWaitForAnalysisCompletion(cobolFile);
+      new JavaPerspective().open();
+      var rootProject = importExistingProjectIntoWorkspace("connected", "connected");
 
-    // even when no language found, the Secrets analyzer should at least give it a shot^^
-    var consoleText = new SonarLintConsole().getConsoleView().getConsoleText();
-    assertThat(consoleText)
-      .contains("Execute Sensor: TextAndSecretsSensor")
-      .doesNotContain("File 'Test.cbl' excluded by 'JavaProjectConfiguratorExtension'");
+      var cobolFile = rootProject.getResource("Test.cbl");
+      openFileAndWaitForAnalysisCompletion(cobolFile);
+
+      // even when no language found, the Secrets analyzer should at least give it a shot^^
+      var consoleText = new SonarLintConsole().getConsoleView().getConsoleText();
+      assertThat(consoleText)
+        .contains("Execute Sensor: TextAndSecretsSensor")
+        .doesNotContain("File 'Test.cbl' excluded by 'JavaProjectConfiguratorExtension'");
+    } finally {
+      consoleView.enableIdeSpecificLogs(false);
+    }
   }
 
   @Test

--- a/its/src/org/sonarlint/eclipse/its/reddeer/views/SonarLintConsole.java
+++ b/its/src/org/sonarlint/eclipse/its/reddeer/views/SonarLintConsole.java
@@ -70,6 +70,16 @@ public class SonarLintConsole {
     }
   }
 
+  public void enableIdeSpecificLogs(boolean enabled) {
+    consoleView.activate();
+    var menu = new ToolItemMenuItem(new DefaultToolItem(consoleView.getCTabItem().getFolder(), "Configure logs"), "IDE-specific traces");
+    if (!menu.isSelected() && enabled) {
+      menu.select();
+    } else if (menu.isSelected() && !enabled) {
+      menu.select();
+    }
+  }
+
   public void showConsole(ShowConsoleOption option) {
     consoleView.activate();
     var menu = new ToolItemMenuItem(new DefaultToolItem(consoleView.getCTabItem().getFolder(), "Show Console"), option.label);

--- a/its/src/org/sonarlint/eclipse/its/reddeer/views/SonarLintConsole.java
+++ b/its/src/org/sonarlint/eclipse/its/reddeer/views/SonarLintConsole.java
@@ -73,9 +73,11 @@ public class SonarLintConsole {
   public void enableIdeSpecificLogs(boolean enabled) {
     consoleView.activate();
     var menu = new ToolItemMenuItem(new DefaultToolItem(consoleView.getCTabItem().getFolder(), "Configure logs"), "IDE-specific traces");
-    if (!menu.isSelected() && enabled) {
-      menu.select();
-    } else if (menu.isSelected() && !enabled) {
+
+    // When the IDE-specific logs are not selected but we want to enable them, we "select" the menu item.
+    // When the IDE-specific logs are selected but we want to disable them, we "de-select" the menu item.
+    // -> `menu.select()` is used for toggling them on/off, not the greatest naming.
+    if ((!menu.isSelected() && enabled) || (menu.isSelected() && !enabled)) {
       menu.select();
     }
   }

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
@@ -112,7 +112,7 @@ public class AnalyzeStandaloneProjectJobTest extends SonarTestCase {
       }
 
       @Override
-      public void trace(@Nullable String msg) {
+      public void traceIdeMessage(@Nullable String msg) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     };

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
@@ -39,6 +39,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -108,6 +109,11 @@ public class AnalyzeStandaloneProjectJobTest extends SonarTestCase {
       @Override
       public void debug(String msg, boolean fromAnalyzer) {
         System.out.println("DEBUG " + msg);
+      }
+
+      @Override
+      public void trace(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
       }
     };
     SonarLintLogger.get().addLogListener(listener);

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonarlint.eclipse.core.SonarLintLogger;
@@ -57,8 +58,11 @@ public class SonarLintProjectConfigurationManagerTest extends SonarTestCase {
       public void debug(String msg, boolean fromAnalyzer) {
       }
 
+      @Override
+      public void trace(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
     });
-
   }
 
   @Test

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
@@ -59,7 +59,7 @@ public class SonarLintProjectConfigurationManagerTest extends SonarTestCase {
       }
 
       @Override
-      public void trace(@Nullable String msg) {
+      public void traceIdeMessage(@Nullable String msg) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
@@ -28,6 +28,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -78,6 +79,10 @@ public class SonarLintMarkerUpdaterTest extends SonarTestCase {
       public void debug(String msg, boolean fromAnalyzer) {
       }
 
+      @Override
+      public void trace(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
     });
     project = importEclipseProject("reference");
   }

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
@@ -80,7 +80,7 @@ public class SonarLintMarkerUpdaterTest extends SonarTestCase {
       }
 
       @Override
-      public void trace(@Nullable String msg) {
+      public void traceIdeMessage(@Nullable String msg) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
@@ -60,7 +60,7 @@ public class DurationUtilsTest {
       }
 
       @Override
-      public void trace(@Nullable String msg) {
+      public void traceIdeMessage(@Nullable String msg) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
@@ -58,6 +58,11 @@ public class DurationUtilsTest {
       @Override
       public void debug(@Nullable String msg, boolean fromAnalyzer) {
       }
+
+      @Override
+      public void trace(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
     });
   }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
@@ -100,9 +100,9 @@ public class SonarLintLogger {
     }
   }
 
-  public void trace(String msg) {
+  public void traceIdeMessage(String msg) {
     for (LogListener listener : logListeners) {
-      listener.trace(msg);
+      listener.traceIdeMessage(msg);
     }
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
@@ -100,4 +100,9 @@ public class SonarLintLogger {
     }
   }
 
+  public void trace(String msg) {
+    for (LogListener listener : logListeners) {
+      listener.trace(msg);
+    }
+  }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
@@ -34,5 +34,5 @@ public interface LogListener {
    *  ones are handled like debug messages. IDE-specific logging is something like adaptations, interaction with an
    *  extension point, ...
    */
-  void trace(@Nullable String msg);
+  void traceIdeMessage(@Nullable String msg);
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
@@ -29,4 +29,10 @@ public interface LogListener {
 
   void debug(@Nullable String msg, boolean fromAnalyzer);
 
+  /**
+   *  This should only be used for IDE-specific logging and is not intended for tracing messages from SLCORE as these
+   *  ones are handled like debug messages. IDE-specific logging is something like adaptations, interaction with an
+   *  extension point, ...
+   */
+  void trace(@Nullable String msg);
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/adapter/DefaultSonarLintAdapterFactory.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/adapter/DefaultSonarLintAdapterFactory.java
@@ -70,7 +70,7 @@ public class DefaultSonarLintAdapterFactory implements IAdapterFactory {
     }
     for (var projectAdapterParticipant : SonarLintExtensionTracker.getInstance().getProjectAdapterParticipants()) {
       if (projectAdapterParticipant.exclude(project)) {
-        SonarLintLogger.get().trace("Project '" + project.getName() + "' excluded by '" + projectAdapterParticipant.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().traceIdeMessage("Project '" + project.getName() + "' excluded by '" + projectAdapterParticipant.getClass().getSimpleName() + "'");
         return null;
       }
     }
@@ -108,7 +108,7 @@ public class DefaultSonarLintAdapterFactory implements IAdapterFactory {
     // Not let's call the ISonarLintFileAdapterParticipant#exclude
     for (var fileAdapterParticipant : SonarLintExtensionTracker.getInstance().getFileAdapterParticipants()) {
       if (fileAdapterParticipant.exclude(file)) {
-        SonarLintLogger.get().trace("File '" + file.getProjectRelativePath() + "' excluded by '" + fileAdapterParticipant.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().traceIdeMessage("File '" + file.getProjectRelativePath() + "' excluded by '" + fileAdapterParticipant.getClass().getSimpleName() + "'");
         return null;
       }
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/adapter/DefaultSonarLintAdapterFactory.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/adapter/DefaultSonarLintAdapterFactory.java
@@ -70,7 +70,7 @@ public class DefaultSonarLintAdapterFactory implements IAdapterFactory {
     }
     for (var projectAdapterParticipant : SonarLintExtensionTracker.getInstance().getProjectAdapterParticipants()) {
       if (projectAdapterParticipant.exclude(project)) {
-        SonarLintLogger.get().debug("Project '" + project.getName() + "' excluded by '" + projectAdapterParticipant.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().trace("Project '" + project.getName() + "' excluded by '" + projectAdapterParticipant.getClass().getSimpleName() + "'");
         return null;
       }
     }
@@ -108,7 +108,7 @@ public class DefaultSonarLintAdapterFactory implements IAdapterFactory {
     // Not let's call the ISonarLintFileAdapterParticipant#exclude
     for (var fileAdapterParticipant : SonarLintExtensionTracker.getInstance().getFileAdapterParticipants()) {
       if (fileAdapterParticipant.exclude(file)) {
-        SonarLintLogger.get().debug("File '" + file.getProjectRelativePath() + "' excluded by '" + fileAdapterParticipant.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().trace("File '" + file.getProjectRelativePath() + "' excluded by '" + fileAdapterParticipant.getClass().getSimpleName() + "'");
         return null;
       }
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/TestFileClassifier.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/TestFileClassifier.java
@@ -66,7 +66,7 @@ public class TestFileClassifier {
   public boolean isTest(ISonarLintFile file) {
     for (var typeProvider : SonarLintExtensionTracker.getInstance().getTypeProviders()) {
       if (typeProvider.qualify(file) == ISonarLintFileType.TEST) {
-        SonarLintLogger.get().debug("File '" + file.getProjectRelativePath() + "' qualified as test by '" + typeProvider.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().trace("File '" + file.getProjectRelativePath() + "' qualified as test by '" + typeProvider.getClass().getSimpleName() + "'");
         return true;
       }
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/TestFileClassifier.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/TestFileClassifier.java
@@ -66,7 +66,7 @@ public class TestFileClassifier {
   public boolean isTest(ISonarLintFile file) {
     for (var typeProvider : SonarLintExtensionTracker.getInstance().getTypeProviders()) {
       if (typeProvider.qualify(file) == ISonarLintFileType.TEST) {
-        SonarLintLogger.get().trace("File '" + file.getProjectRelativePath() + "' qualified as test by '" + typeProvider.getClass().getSimpleName() + "'");
+        SonarLintLogger.get().traceIdeMessage("File '" + file.getProjectRelativePath() + "' qualified as test by '" + typeProvider.getClass().getSimpleName() + "'");
         return true;
       }
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -200,13 +200,13 @@ public class SonarLintUtils {
   @Nullable
   public static <T> T adapt(@Nullable Object sourceObject, Class<T> adapter, String trace) {
     if (sourceObject == null) {
-      SonarLintLogger.get().debug(trace);
+      SonarLintLogger.get().trace(trace);
       return null;
     }
 
     var adapted = Adapters.adapt(sourceObject, adapter);
     if (adapted == null) {
-      SonarLintLogger.get().debug(trace + " -> '" + sourceObject.toString() + "' could not be adapted to '"
+      SonarLintLogger.get().trace(trace + " -> '" + sourceObject.toString() + "' could not be adapted to '"
         + adapter.getCanonicalName() + "'");
     }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -200,13 +200,13 @@ public class SonarLintUtils {
   @Nullable
   public static <T> T adapt(@Nullable Object sourceObject, Class<T> adapter, String trace) {
     if (sourceObject == null) {
-      SonarLintLogger.get().trace(trace);
+      SonarLintLogger.get().traceIdeMessage(trace);
       return null;
     }
 
     var adapted = Adapters.adapt(sourceObject, adapter);
     if (adapted == null) {
-      SonarLintLogger.get().trace(trace + " -> '" + sourceObject.toString() + "' could not be adapted to '"
+      SonarLintLogger.get().traceIdeMessage(trace + " -> '" + sourceObject.toString() + "' could not be adapted to '"
         + adapter.getCanonicalName() + "'");
     }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/Messages.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/Messages.java
@@ -52,6 +52,7 @@ public final class Messages extends NLS {
   public static String ConfigureLoggingAction_tooltip;
   public static String ConfigureLoggingAction_verbose_text;
   public static String ConfigureLoggingAction_analyzer_text;
+  public static String ConfigureLoggingAction_ide_tracing;
 
   public static String PropertyAndPreferencePage_useprojectsettings_label;
   public static String PropertyAndPreferencePage_useworkspacesettings_change;

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -113,9 +113,9 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
     }
 
     @Override
-    public void trace(@Nullable String msg) {
+    public void traceIdeMessage(@Nullable String msg) {
       if (PlatformUI.isWorkbenchRunning()) {
-        doAsyncInUiThread(() -> getSonarConsole().trace(msg));
+        doAsyncInUiThread(() -> getSonarConsole().traceIdeMessage(msg));
       }
     }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -112,6 +112,13 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
       }
     }
 
+    @Override
+    public void trace(@Nullable String msg) {
+      if (PlatformUI.isWorkbenchRunning()) {
+        doAsyncInUiThread(() -> getSonarConsole().trace(msg));
+      }
+    }
+
     void doAsyncInUiThread(Runnable task) {
       logConsumer.submit(() -> Display.getDefault().syncExec(task));
     }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
@@ -354,6 +354,8 @@ public class SonarLintEclipseRpcClient extends SonarLintEclipseHeadlessRpcClient
       ? ("\n\n" + params.getStackTrace())
       : "";
 
+    // The tracing coming from SLCORE should not be confused with the SonarLintLogger#trace(String) message! This is
+    // only to be used for IDE-specific logging (e.g. adaptations, interaction with extension points, ...)
     switch (params.getLevel()) {
       case TRACE:
       case DEBUG:

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
@@ -354,8 +354,8 @@ public class SonarLintEclipseRpcClient extends SonarLintEclipseHeadlessRpcClient
       ? ("\n\n" + params.getStackTrace())
       : "";
 
-    // The tracing coming from SLCORE should not be confused with the SonarLintLogger#trace(String) message! This is
-    // only to be used for IDE-specific logging (e.g. adaptations, interaction with extension points, ...)
+    // The tracing coming from SLCORE should not be confused with the SonarLintLogger#traceIdeMessage(String) message!
+    // This is only to be used for IDE-specific logging (e.g. adaptations, interaction with extension points, ...)
     switch (params.getLevel()) {
       case TRACE:
       case DEBUG:

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsole.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsole.java
@@ -137,7 +137,7 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
     }
   }
 
-  public void trace(String msg) {
+  public void traceIdeMessage(String msg) {
     if (showIdeSpecificTracing()) {
       if (isShowConsoleOnOutput()) {
         bringConsoleToFront();

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsole.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsole.java
@@ -38,6 +38,7 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
 
   public static final String P_VERBOSE_OUTPUT = "debugOutput"; //$NON-NLS-1$
   public static final String P_ANALYZER_OUTPUT = "showAnalyzerOutput"; //$NON-NLS-1$
+  public static final String P_IDE_TRACING_OUTPUT = "ideSpecificTracing"; //$NON-NLS-1$
   public static final String P_SHOW_CONSOLE = "showConsole"; //$NON-NLS-1$
   public static final String P_SHOW_CONSOLE_NEVER = "never"; //$NON-NLS-1$
   public static final String P_SHOW_CONSOLE_ON_OUTPUT = "onOutput"; //$NON-NLS-1$
@@ -48,12 +49,14 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
   private final MessageConsoleStream infoStream;
   private final MessageConsoleStream warnStream;
   private final MessageConsoleStream debugStream;
+  private final MessageConsoleStream traceStream;
 
   public SonarLintConsole(ImageDescriptor imageDescriptor) {
     super(TITLE, imageDescriptor);
     this.infoStream = newMessageStream();
     this.warnStream = newMessageStream();
     this.debugStream = newMessageStream();
+    this.traceStream = newMessageStream();
   }
 
   @Override
@@ -68,7 +71,7 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
 
     var linkColor = colorRegistry.get(JFacePreferences.HYPERLINK_COLOR);
     if (linkColor == null) {
-      linkColor = JFaceColors.getActiveHyperlinkText(display);
+      linkColor = JFaceColors.getHyperlinkText(display);
     }
 
     var errorColorColor = colorRegistry.get(JFacePreferences.ERROR_COLOR);
@@ -76,8 +79,14 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
       errorColorColor = JFaceColors.getErrorText(display);
     }
 
+    var activeLinkColor = colorRegistry.get(JFacePreferences.ACTIVE_HYPERLINK_COLOR);
+    if (activeLinkColor == null) {
+      activeLinkColor = JFaceColors.getActiveHyperlinkText(display);
+    }
+
     getWarnStream().setColor(errorColorColor);
     getDebugStream().setColor(linkColor);
+    getTraceStream().setColor(activeLinkColor);
   }
 
   public void bringConsoleToFront() {
@@ -128,6 +137,15 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
     }
   }
 
+  public void trace(String msg) {
+    if (showIdeSpecificTracing()) {
+      if (isShowConsoleOnOutput()) {
+        bringConsoleToFront();
+      }
+      write(getTraceStream(), msg);
+    }
+  }
+
   private static void write(MessageConsoleStream stream, String msg) {
     if (msg == null) {
       return;
@@ -145,6 +163,10 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
 
   public MessageConsoleStream getDebugStream() {
     return debugStream;
+  }
+
+  public MessageConsoleStream getTraceStream() {
+    return traceStream;
   }
 
   private static String getShowConsolePreference() {
@@ -165,6 +187,10 @@ public class SonarLintConsole extends MessageConsole implements IPropertyChangeL
 
   public static boolean showAnalysisLogs() {
     return SonarLintUiPlugin.getDefault().getPreferenceStore().getBoolean(SonarLintConsole.P_ANALYZER_OUTPUT);
+  }
+
+  public static boolean showIdeSpecificTracing() {
+    return SonarLintUiPlugin.getDefault().getPreferenceStore().getBoolean(SonarLintConsole.P_IDE_TRACING_OUTPUT);
   }
 
   @Override

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsolePageParticipant.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/console/SonarLintConsolePageParticipant.java
@@ -167,6 +167,7 @@ public class SonarLintConsolePageParticipant implements IConsolePageParticipant 
       menu = new Menu(parent);
       addActionToMenu(menu, new MyAction(Messages.ConfigureLoggingAction_verbose_text, SonarLintConsole.P_VERBOSE_OUTPUT));
       addActionToMenu(menu, new MyAction(Messages.ConfigureLoggingAction_analyzer_text, SonarLintConsole.P_ANALYZER_OUTPUT));
+      addActionToMenu(menu, new MyAction(Messages.ConfigureLoggingAction_ide_tracing, SonarLintConsole.P_IDE_TRACING_OUTPUT));
       return menu;
     }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/messages.properties
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/messages.properties
@@ -42,6 +42,7 @@ SonarShowConsoleAction_onError_text=On error
 ConfigureLoggingAction_tooltip=Configure logs
 ConfigureLoggingAction_verbose_text=Verbose output
 ConfigureLoggingAction_analyzer_text=Analysis logs
+ConfigureLoggingAction_ide_tracing=IDE-specific traces
 
 PropertyAndPreferencePage_useprojectsettings_label=Enable project specific settings
 PropertyAndPreferencePage_useworkspacesettings_change=Configure Workspace Settings...

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencesInitializer.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencesInitializer.java
@@ -32,7 +32,9 @@ public class SonarLintPreferencesInitializer extends AbstractPreferenceInitializ
   public void initializeDefaultPreferences() {
     var node = DefaultScope.INSTANCE.getNode(SonarLintUiPlugin.PLUGIN_ID);
     node.put(SonarLintConsole.P_SHOW_CONSOLE, SonarLintConsole.P_SHOW_CONSOLE_ON_ERROR);
+    node.putBoolean(SonarLintConsole.P_VERBOSE_OUTPUT, false);
     node.putBoolean(SonarLintConsole.P_ANALYZER_OUTPUT, false);
+    node.putBoolean(SonarLintConsole.P_IDE_TRACING_OUTPUT, false);
     node.putInt(SonarLintGlobalConfiguration.PREF_MARKER_SEVERITY, SonarLintGlobalConfiguration.PREF_MARKER_SEVERITY_DEFAULT);
     node.putBoolean(SonarLintGlobalConfiguration.PREF_ISSUE_INCLUDE_RESOLVED, false);
     node.putBoolean(SonarLintGlobalConfiguration.PREF_ISSUE_ONLY_NEW_CODE, false);


### PR DESCRIPTION
## Summary

The **SonarLint Console** of the builtin Console view currently offers the user the option to display the *Verbose output* (containing the debug statements) and the *Analysis logs* next to the default output.

For the last release, I changed the behavior for Eclipse-specific invocations (e.g., adaptations or extension-point interaction) to also log their output that can be used when debugging third-party integrations with SonarLint (e.g., from IBM Developer for z/OS). These logs are very useful but pollute the output for users who want to debug "normal" issues with SonarLint.

See this exemplary screenshot for example, on how much of the output is not coming from either the *Verbose output* (actual debug logs of SonarLint logic) and *Analysis logs*. Colors are OS-specific but differ:

![Screenshot from 2024-06-20 14-15-00](https://github.com/SonarSource/sonarlint-eclipse/assets/6588381/2e284d6a-f839-4887-8bb3-ca5c7f3d5170)

In order to keep the normal *Verbose output* simple and SonarLint-logic-specific, a new option, *IDE-specific traces*, was added to the **SonarLint Console** that can be enabled separately when we ask for it. For now, the behavior for asking users for "logs" will be for them to have *Verbose output* and *Analysis logs* enabled, they are distinguished by color.
When we want to go into more detail, as this is not used in most cases, we can ask them to also enable the *IDE-specific traces* option - it is called *tracing* in context of Eclipse IDE.

## Testing

This is already used in the `StandaloneAnalysisTest#test_jdt_java_like_extension_COBOL()` but is not necessary for the other unit/integration tests. Therefore the option is disabled by default.