### PR TITLE
SLE-890: Java 21 for Cirrus CI, Orchestrator with correct Java environment

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -198,9 +198,15 @@ qa_task:
     ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4
   run_its_script: |
     echo "Run Maven ITs for Eclipse ${TARGET_PLATFORM} and Server ${SQ_VERSION}"
+
+    ORCHESTRATOR_CONFIG="-Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator.properties"
+    if [[ "${TARGET_PLATFORM}" == "oldest" ]]; then
+      ORCHESTRATOR_CONFIG="-Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator-oldest.properties"
+    fi
+
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify -f its/pom.xml -Pcoverage \
       -Dtarget.platform=${TARGET_PLATFORM} -Dtycho.localArtifacts=ignore -Dsonarlint-eclipse.p2.url="file://${CIRRUS_WORKING_DIR}/staged-repository" -Dsonar.runtimeVersion=${SQ_VERSION} \
-      -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/it-coverage.exec
+      -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/it-coverage.exec $ORCHESTRATOR_CONFIG
     mv it-coverage.exec it-coverage-${QA_CATEGORY}.exec
   cleanup_before_cache_script: cleanup_maven_repository
   always:

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -38,7 +38,6 @@ maven_cache_qa: &SETUP_MAVEN_CACHE
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
     fingerprint_script:
-      - echo $TARGET_PLATFORM
       - /usr/bin/find . -name pom.xml -not -path './its/*' -exec cat {} \+
       - cat target-platforms/build.target target-platforms/commons.target its/target-platforms/*.target
 
@@ -72,19 +71,6 @@ qa_ibuilds_task:
     SONARCLOUD_IT_PASSWORD: VAULT[development/team/sonarlint/kv/data/sonarcloud-it data.password]
     DISPLAY: :10
     MAVEN_OPTS: -Xmx3072m
-  matrix:
-    - env:
-        TARGET_PLATFORM: 'ibuilds'
-        SQ_VERSION: 'LATEST_RELEASE[8.9]'
-        QA_CATEGORY: 'Oldest'
-    - env:
-        TARGET_PLATFORM: 'ibuilds'
-        SQ_VERSION: 'LATEST_RELEASE[9.9]'
-        QA_CATEGORY: 'Latest-LTS'
-    - env:
-        TARGET_PLATFORM: 'ibuilds'
-        SQ_VERSION: 'DEV'
-        QA_CATEGORY: 'Latest'
   <<: *SETUP_MAVEN_CACHE
   <<: *SETUP_ORCHESTRATOR_CACHE
   prepare_update_site_script: |
@@ -98,13 +84,14 @@ qa_ibuilds_task:
     metacity --sm-disable --replace &
     sleep 10 # give metacity some time to start
     echo 'Recording tests on video'
-    ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4
+    ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording.mp4
   run_its_script: |
-    echo "Run Maven ITs for Eclipse iBuilds and Server ${SQ_VERSION}"
+    echo "Run Maven ITs for Eclipse iBuilds and SonarQube 9.9 LTS"
     mvn -B -e -V verify -f its/pom.xml \
-      -Dtarget.platform=${TARGET_PLATFORM} -Dtycho.localArtifacts=ignore \
+      -Dtarget.platform=ibuilds -Dtycho.localArtifacts=ignore \
       -Dsonarlint-eclipse.p2.url="file://${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.site/target/repository" \
-      -Dsonar.runtimeVersion=${SQ_VERSION}
+      -Dsonar.runtimeVersion="LATEST_RELEASE[9.9]" \
+      -Dorchestrator.configUrl=file:///$CIRRUS_WORKING_DIR/its/orchestrator.properties
   cleanup_before_cache_script: cleanup_maven_repository
   always:
     stop_recording_script: |
@@ -112,7 +99,7 @@ qa_ibuilds_task:
       while pgrep ffmpeg >/dev/null; do sleep 1; done
       /etc/init.d/xvfb stop
     test_recording_artifacts:
-      path: "${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4"
+      path: "${CIRRUS_WORKING_DIR}/recording.mp4"
   on_failure:
     xvfb_log_artifacts:
       path: "${CIRRUS_WORKING_DIR}/Xvfb.out"

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -1,11 +1,13 @@
 ARG CIRRUS_AWS_ACCOUNT=275878209202
 ARG JDK_VERSION=17
-FROM public.ecr.aws/docker/library/eclipse-temurin:11-jammy AS buildphase
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jammy AS buildphase-11
+FROM public.ecr.aws/docker/library/eclipse-temurin:21-jammy AS buildphase-21
 
 FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j${JDK_VERSION}-m3.9-latest
 
 USER root
-COPY --from=buildphase /opt/java/openjdk /opt/java/openjdk-11
+COPY --from=buildphase-11 /opt/java/openjdk /opt/java/openjdk-11
+COPY --from=buildphase-21 /opt/java/openjdk /opt/java/openjdk-21
 
 # AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
@@ -22,4 +24,5 @@ COPY --chmod=755 .cirrus/init.d/xvfb /etc/init.d/
 USER sonarsource
 ENV JAVA_HOME_11_X64=/opt/java/openjdk-11
 ENV JAVA_HOME_17_X64=/opt/java/openjdk
+ENV JAVA_HOME_21_X64=/opt/java/openjdk-21
 COPY --chown=sonarsource .cirrus/toolchains.xml .m2/toolchains.xml

--- a/.cirrus/toolchains.xml
+++ b/.cirrus/toolchains.xml
@@ -22,4 +22,14 @@
       <jdkHome>${env.JAVA_HOME_17_X64}</jdkHome>
     </configuration>
   </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <id>JavaSE-21</id>
+      <version>21</version>
+    </provides>
+    <configuration>
+      <jdkHome>${env.JAVA_HOME_21_X64}</jdkHome>
+    </configuration>
+  </toolchain>
 </toolchains>

--- a/its/orchestrator-oldest.properties
+++ b/its/orchestrator-oldest.properties
@@ -1,0 +1,6 @@
+# Currently the oldest target platform is still running with Eclipse IDE based on Java 11 and
+# against SonarQube 8.9 LTS! Once support for SonarQube < 9.9 LTS is dropped, this can be removed
+# since then even the oldest supported SonarQube version (9.9 LTS) will require Java 17 to run.
+#
+# -> Also drop the changes in ".cirrus.default.yml"!
+java.home=/opt/java/openjdk-11

--- a/its/orchestrator.properties
+++ b/its/orchestrator.properties
@@ -1,0 +1,4 @@
+# Currently the "iBuilds" target platform is running with Eclipse IDE based on Java 21 and against
+# SonarQube 9.9 LTS that is only compatible with Java 17! The latest target platform is already
+# running with Java 17.
+java.home=/opt/java/openjdk


### PR DESCRIPTION
## Summary

Since Eclipse 2024-06 (4.32), released a few days ago, is bundled with Java 21, and the first plug-ins (e.g., WWW) require Java 21 as well, we need it to run the iBuilds pipeline correctly. SonarQube doesn't run on Java 21, and therefore, the Orchestrator for SQ 9.9+ must run against Java 17.
The workaround for SQ 8.9 will only be in place until SLE-806 is merged; after that, the whole SQ 8.9 axis will disappear including the orchestrator configuration.