### PR TITLE
NO-JIRA: Don't run unit tests again for SonarQube

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -267,7 +267,7 @@ sonarqube_task:
     unzip jacoco.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
     source cirrus-env QA
     .cirrus/regular_mvn_build_deploy_analyze \
-      -P-deploy-sonarsource,-release,-sign -Dmaven.install.skip=true -Dmaven.deploy.skip=true \
+      -P-deploy-sonarsource,-release,-sign -Dmaven.install.skip=true -DskipTests -Dmaven.deploy.skip=true \
       -Pcoverage -Djacoco.append=true -Dsonar.coverage.jacoco.xmlReportPaths=${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/site/jacoco-aggregate/jacoco.xml
     /etc/init.d/xvfb stop
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -134,9 +134,13 @@ validate_task:
     metacity --sm-disable --replace &
     sleep 10 # give metacity some time to start
     source cirrus-env QA
-    mvn -B -e -V verify -P-deploy-sonarsource,-release,-sign
+    mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify -Pcoverage \
+      -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/ut-coverage.exec
     /etc/init.d/xvfb stop
   cleanup_before_cache_script: cleanup_maven_repository
+  always:
+    jacoco_ut_artifacts:
+      path: "${CIRRUS_WORKING_DIR}/ut-coverage*.exec"
   on_failure:
     mvn_startTestLog_artifacts:
       path: "${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/work/configuration/*.log"
@@ -211,7 +215,7 @@ qa_task:
       /etc/init.d/xvfb stop
     test_recording_artifacts:
       path: "${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4"
-    jacoco_artifacts:
+    jacoco_it_artifacts:
       path: "${CIRRUS_WORKING_DIR}/it-coverage*.exec"
   on_failure:
     xvfb_log_artifacts:
@@ -244,6 +248,7 @@ inspect_orchestrator_cache_task:
 sonarqube_task:
   # name: "Run SonarQube analysis"
   depends_on:
+    - validate
     - qa
   <<: *ONLY_IF_EXCEPT_NIGHTLY
   eks_container:
@@ -263,8 +268,10 @@ sonarqube_task:
   sonarqube_script: |
     set -euo pipefail
     mkdir ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
-    curl --no-progress-meter https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/jacoco.zip -o jacoco.zip
-    unzip jacoco.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
+    curl --no-progress-meter https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/jacoco_ut.zip -o jacoco_ut.zip
+    curl --no-progress-meter https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/jacoco_it.zip -o jacoco_it.zip
+    unzip jacoco_ut.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
+    unzip jacoco_it.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
     source cirrus-env QA
     .cirrus/regular_mvn_build_deploy_analyze \
       -P-deploy-sonarsource,-release,-sign -Dmaven.install.skip=true -DskipTests -Dmaven.deploy.skip=true \


### PR DESCRIPTION
This is primarily used to not be blocked if unit tests decide to be flaky here instead of the actual unit-test-invoking "validate" task. On the other hand it speeds up the build by a minute or so.