### PR TITLE
SLE-884: Open in IDE from SonarCloud

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
@@ -127,7 +127,7 @@ public class AnalyzeStandaloneProjectJobTest extends SonarTestCase {
     var allProjectsReady = new CountDownLatch(1);
     Executors.newSingleThreadExecutor().submit(() -> {
       while (true) {
-        var map = new HashMap<String, Boolean>(AnalyzeProjectJob.analysisReadyByConfigurationScopeId);
+        var map = new HashMap<String, Boolean>(AnalysisReadyStatusCache.getCache());
         if (!map.isEmpty() && map.values().stream().allMatch(Boolean::booleanValue)) {
           allProjectsReady.countDown();
           break;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -53,7 +53,6 @@ import org.sonarlint.eclipse.core.internal.utils.DurationUtils;
 import org.sonarlint.eclipse.core.internal.utils.JavaRuntimeUtils;
 import org.sonarlint.eclipse.core.internal.utils.SonarLintUtils;
 import org.sonarlint.eclipse.core.internal.vcs.VcsService;
-import org.sonarlint.eclipse.core.resource.ISonarLintFile;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarsource.sonarlint.core.rpc.client.SloopLauncher;
 import org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientDelegate;
@@ -63,6 +62,8 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFiles
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.branch.DidVcsRepositoryChangeParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.branch.GetMatchedSonarProjectBranchParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.branch.GetMatchedSonarProjectBranchResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidChangeCredentialsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetAllProjectsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.SonarProjectDto;
@@ -284,6 +285,14 @@ public class SonarLintBackendService {
     getBackend()
       .getSonarProjectBranchService()
       .didVcsRepositoryChange(new DidVcsRepositoryChangeParams(ConfigScopeSynchronizer.getConfigScopeId(project)));
+  }
+
+  public GetMatchedSonarProjectBranchResponse getMatchedSonarProjectBranch(ISonarLintProject project)
+    throws InterruptedException, ExecutionException {
+    return getBackend()
+      .getSonarProjectBranchService()
+      .getMatchedSonarProjectBranch(new GetMatchedSonarProjectBranchParams(ConfigScopeSynchronizer.getConfigScopeId(project)))
+      .get();
   }
 
   public void credentialsChanged(ConnectionFacade connection) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalysisReadyStatusCache.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/jobs/AnalysisReadyStatusCache.java
@@ -1,0 +1,51 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.core.internal.jobs;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *  Because we have to await SonarLint out of Process to get ready (e.g. on startup or when a new connection/binding
+ *  was established for projects, changes to configurations), we have to keep the information, that might change, in
+ *  sync as different parts of SonarLint rely on that information (e.g. analysis itself, Open in IDE).
+ *
+ *  The cache can be accessed from different threads and Eclipse platform jobs (basically fancy threads) and therefore
+ *  must be thread safe!
+ */
+public class AnalysisReadyStatusCache {
+  private static final Map<String, Boolean> analysisReadyByConfigurationScopeId = new ConcurrentHashMap<>();
+
+  private AnalysisReadyStatusCache() {
+    // utility class
+  }
+
+  public static Map<String, Boolean> getCache() {
+    return analysisReadyByConfigurationScopeId;
+  }
+
+  public static void changeAnalysisReadiness(String configurationScopeId, boolean readiness) {
+    analysisReadyByConfigurationScopeId.put(configurationScopeId, readiness);
+  }
+
+  public static boolean getAnalysisReadiness(String configurationScopeId) {
+    return analysisReadyByConfigurationScopeId.getOrDefault(configurationScopeId, false);
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/backend/SonarLintEclipseRpcClient.java
@@ -39,7 +39,7 @@ import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.TriggerType;
 import org.sonarlint.eclipse.core.internal.backend.ConfigScopeSynchronizer;
 import org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessRpcClient;
-import org.sonarlint.eclipse.core.internal.jobs.AnalyzeProjectJob;
+import org.sonarlint.eclipse.core.internal.jobs.AnalysisReadyStatusCache;
 import org.sonarlint.eclipse.core.internal.jobs.TaintIssuesMarkerUpdateJob;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.telemetry.SonarLintTelemetry;
@@ -327,7 +327,7 @@ public class SonarLintEclipseRpcClient extends SonarLintEclipseHeadlessRpcClient
 
     // Handle expensive checks and actual logic in separate job to not block the thread
     new OpenIssueInEclipseJob(new OpenIssueContext("Open in IDE", issueDetails, project, bindingOpt.get()))
-      .schedule();
+      .schedule(500);
   }
 
   @Override
@@ -391,7 +391,8 @@ public class SonarLintEclipseRpcClient extends SonarLintEclipseHeadlessRpcClient
         + "' changed ready status for analysis to: " + areReadyForAnalysis);
     }
 
-    AnalyzeProjectJob.changeAnalysisReadiness(configurationScopeIds, areReadyForAnalysis);
+    configurationScopeIds.stream()
+      .forEach(configurationScopeId -> AnalysisReadyStatusCache.changeAnalysisReadiness(configurationScopeId, areReadyForAnalysis));
     if (areReadyForAnalysis) {
       AnalysisJobsScheduler.scheduleAnalysisOfOpenFiles(projects, TriggerType.ANALYSIS_READY);
     }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AbstractAssistCreatingConnectionJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AbstractAssistCreatingConnectionJob.java
@@ -55,12 +55,16 @@ public abstract class AbstractAssistCreatingConnectionJob extends UIJob {
   public IStatus runInUIThread(IProgressMonitor monitor) {
     var shell = DisplayUtils.bringToFront();
 
-    // Currently we only ask the user if they trust a SonarQube server, SonarCloud we trust of course!
+    // In order to not blindly accept incoming connection requests via the "Open in IDE" feature, we will trigger a
+    // pop-up for the user to manually allow setting up the connection and trusting it.
+    AbstractConfirmConnectionCreationDialog dialog;
     if (serverUrlOrOrganization.isLeft()) {
-      var dialog = new ConfirmConnectionCreationDialog(shell, serverUrlOrOrganization.getLeft(), automaticSetUp);
-      if (dialog.open() != 0) {
-        return Status.CANCEL_STATUS;
-      }
+      dialog = new ConfirmSonarQubeConnectionCreationDialog(shell, serverUrlOrOrganization.getLeft(), automaticSetUp);
+    } else {
+      dialog = new ConfirmSonarCloudConnectionCreationDialog(shell, serverUrlOrOrganization.getRight(), automaticSetUp);
+    }
+    if (dialog.open() != 0) {
+      return Status.CANCEL_STATUS;
     }
 
     var model = new ServerConnectionModel(fromConnectionSuggestion);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AbstractConfirmConnectionCreationDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/AbstractConfirmConnectionCreationDialog.java
@@ -29,22 +29,22 @@ import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
 
-class ConfirmConnectionCreationDialog extends MessageDialog {
-
-  public ConfirmConnectionCreationDialog(Shell parentShell, String serverUrl, boolean automaticSetUp) {
-    super(parentShell, "Do you trust this SonarQube server?", SonarLintImages.BALLOON_IMG,
-      "The server at \"" + serverUrl + "\" is attempting to set up a connection with SonarLint. Letting SonarLint "
-      + "connect to an untrusted server is potentially dangerous."
-      + (automaticSetUp ? " The following setup will be done automatically." : ""),
-      MessageDialog.WARNING, new String[] {"Connect to this SonarQube server", "I don't trust this server"}, 0);
+public abstract class AbstractConfirmConnectionCreationDialog extends MessageDialog {
+  protected AbstractConfirmConnectionCreationDialog(Shell parentShell, String dialogTitle, String dialogMessage, String connectLabel, boolean automaticSetUp) {
+    super(parentShell,
+      dialogTitle,
+      SonarLintImages.BALLOON_IMG,
+      dialogMessage + (automaticSetUp ? " The following setup will be done automatically." : ""),
+      MessageDialog.WARNING,
+      new String[] {connectLabel, "I don't trust this connection"},
+      0);
   }
 
   @Override
   protected Control createCustomArea(Composite parent) {
     var link = new Link(parent, SWT.WRAP);
-    link.setText("If you don't trust this server, we recommend canceling this action and <a>manually setting up Connected Mode</a>.");
+    link.setText("If you don't trust this connection, we recommend canceling this action and <a>manually setting up Connected Mode</a>.");
     link.addListener(SWT.Selection, e -> BrowserUtils.openExternalBrowserWithTelemetry(LinkTelemetry.CONNECTED_MODE_DOCS, e.display));
     return link;
   }
-
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarCloudConnectionCreationDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarCloudConnectionCreationDialog.java
@@ -1,0 +1,32 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.binding.assist;
+
+import org.eclipse.swt.widgets.Shell;
+
+public class ConfirmSonarCloudConnectionCreationDialog extends AbstractConfirmConnectionCreationDialog {
+  public ConfirmSonarCloudConnectionCreationDialog(Shell parentShell, String organization, boolean automaticSetUp) {
+    super(parentShell,
+      "Do you trust SonarCloud?",
+      "SonarCloud is attempting to set up a connection for the organization '" + organization + "' with SonarLint.",
+      "Connect to SonarCloud",
+      automaticSetUp);
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarQubeConnectionCreationDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarQubeConnectionCreationDialog.java
@@ -1,0 +1,33 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.binding.assist;
+
+import org.eclipse.swt.widgets.Shell;
+
+public class ConfirmSonarQubeConnectionCreationDialog extends AbstractConfirmConnectionCreationDialog {
+  public ConfirmSonarQubeConnectionCreationDialog(Shell parentShell, String serverUrl, boolean automaticSetUp) {
+    super(parentShell,
+      "Do you trust this SonarQube server?",
+      "The server at '" + serverUrl + "' is attempting to set up a connection with SonarLint. Letting SonarLint "
+        + "connect to an untrusted server is potentially dangerous.",
+      "Connect to this SonarQube server",
+      automaticSetUp);
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/AwaitProjectConnectionReadyDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/AwaitProjectConnectionReadyDialog.java
@@ -1,0 +1,81 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.dialog;
+
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.sonarlint.eclipse.ui.internal.SonarLintImages;
+import org.sonarlint.eclipse.ui.internal.job.AwaitProjectConnectionReadyJob;
+
+/**
+ *  This dialog is linked to {@link org.sonarlint.eclipse.ui.internal.job.AwaitProjectConnectionReadyJob}!
+ *
+ *  This dialog will be shown to users when an action should be performed that requires a connection to be fully
+ *  established. E.g. the "Open in IDE" feature that needs to run an analysis, that is only ready after the connection
+ *  is fully working (analyzers, quality gates downloaded etc).
+ */
+public class AwaitProjectConnectionReadyDialog extends MessageDialog {
+  private ClosingReason reason = ClosingReason.CLOSED_BY_USER;
+  private boolean closed = false;
+
+  public AwaitProjectConnectionReadyDialog(Shell parentShell) {
+    super(parentShell,
+      "Await Connected Mode to get ready",
+      SonarLintImages.BALLOON_IMG,
+      "In order to proceed we have to wait for the Connected Mode to get ready. Depending on your network connection "
+        + "it can take some time, at most SonarLint will wait for " + AwaitProjectConnectionReadyJob.maxWaitTime()
+        + " minute(s). When everything is finished this dialog will be closed automatically and SonarLint will "
+        + "proceed. If you click 'Cancel', the Connected Mode will still be established but the requested issue will "
+        + "not be displayed.",
+      INFORMATION,
+      new String[] {"Cancel"},
+      0);
+  }
+
+  @Override
+  protected Control createDialogArea(Composite parent) {
+    parent.getShell().addDisposeListener(e -> closed = true);
+    return super.createDialogArea(parent);
+  }
+
+  public void closeByJob(boolean success) {
+    reason = success ? ClosingReason.CLOSED_BY_JOB_SUCCESS : ClosingReason.CLOSED_BY_JOB_CANCEL;
+  }
+
+  public boolean cancelledByUser() {
+    return reason.equals(ClosingReason.CLOSED_BY_USER);
+  }
+
+  public boolean cancelledByJob() {
+    return reason.equals(ClosingReason.CLOSED_BY_JOB_CANCEL);
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  private enum ClosingReason {
+    CLOSED_BY_JOB_SUCCESS,
+    CLOSED_BY_JOB_CANCEL,
+    CLOSED_BY_USER
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/AwaitProjectConnectionReadyJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/AwaitProjectConnectionReadyJob.java
@@ -1,0 +1,78 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.job;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.widgets.Display;
+import org.sonarlint.eclipse.core.internal.backend.ConfigScopeSynchronizer;
+import org.sonarlint.eclipse.core.internal.jobs.AnalysisReadyStatusCache;
+import org.sonarlint.eclipse.core.resource.ISonarLintProject;
+import org.sonarlint.eclipse.ui.internal.dialog.AwaitProjectConnectionReadyDialog;
+
+/**
+ *  This job is linked to the {@link org.sonarlint.eclipse.ui.internal.dialog.AwaitProjectConnectionReadyDialog}!
+ *
+ *  This job is running in the background of the dialog awaiting the analysis to get ready for the project indicating
+ *  that the connection is now ready. It will trigger itself and takes at most 1 minute.
+ */
+public class AwaitProjectConnectionReadyJob extends Job {
+  public static final int SCHEDULE_TIMER_MS = 250;
+  public static final int SCHEDULE_ITERATIONS = 240;
+
+  private final ISonarLintProject project;
+  private final AwaitProjectConnectionReadyDialog dialog;
+  private final int iteration;
+
+  public AwaitProjectConnectionReadyJob(ISonarLintProject project, AwaitProjectConnectionReadyDialog dialog, int iteration) {
+    super("Await connection to get ready in the background");
+    this.project = project;
+    this.dialog = dialog;
+    this.iteration = iteration;
+  }
+
+  @Override
+  protected IStatus run(IProgressMonitor monitor) {
+    if (dialog.isClosed()) {
+      return Status.OK_STATUS;
+    } else if (AnalysisReadyStatusCache.getAnalysisReadiness(ConfigScopeSynchronizer.getConfigScopeId(project))) {
+      closeDialog(true);
+      return Status.OK_STATUS;
+    } else if (iteration >= SCHEDULE_ITERATIONS) {
+      closeDialog(false);
+      return Status.CANCEL_STATUS;
+    }
+
+    new AwaitProjectConnectionReadyJob(project, dialog, iteration + 1)
+      .schedule(SCHEDULE_TIMER_MS);
+    return Status.OK_STATUS;
+  }
+
+  private void closeDialog(boolean success) {
+    dialog.closeByJob(success);
+    Display.getDefault().syncExec(dialog::close);
+  }
+
+  public static int maxWaitTime() {
+    return AwaitProjectConnectionReadyJob.SCHEDULE_ITERATIONS * AwaitProjectConnectionReadyJob.SCHEDULE_TIMER_MS / 60000;
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
@@ -86,13 +86,16 @@ public final class PlatformUtils {
   /**
    *  Opens editor for given marker.
    */
-  public static void openEditor(IMarker marker) {
+  @Nullable
+  public static IEditorPart openEditor(IMarker marker) {
+    IEditorPart part = null;
     var page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
     try {
-      IDE.openEditor(page, marker);
+      part = IDE.openEditor(page, marker);
     } catch (PartInitException e) {
       SonarLintLogger.get().error(e.getMessage(), e);
     }
+    return part;
   }
 
   /**


### PR DESCRIPTION
## Summary

Some changes had to be made to the assistance for connection creation in order to support SonarCloud alongside SonarQube for the **Open in IDE** feature and automatic Connected Mode setup in this case.

Additionally, for the automatic Connected Mode part the user experience was enhanced by waiting for the connection synchronization (and therefore analysis readiness) to be finished. These were some slightly bigger changes that will only trigger when not yet connected and triggering **Open in IDE**. When already bound, the logic is the same and not changed from the implementation done for SonarQube.

## Testing

There are no integration tests for SonarCloud as it is not in production. It was tested manually. Issues as described [HERE](https://sonarsource.atlassian.net/browse/SLE-797) were not fixed with this PR; they will be tackled either next week or when the Sonar Solution Squad is available.