### PR TITLE
SLE-798: Add IT for custom secrets

### DIFF
--- a/its/projects/secrets/secrets-custom/.project
+++ b/its/projects/secrets/secrets-custom/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>secrets-custom</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/its/projects/secrets/secrets-custom/Heresy.txt
+++ b/its/projects/secrets/secrets-custom/Heresy.txt
@@ -1,0 +1,1 @@
+IntelliJ will rule the world!

--- a/its/res/custom-secrets.xml
+++ b/its/res/custom-secrets.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile>
+  <name>SonarLint IT Custom Secrets</name>
+  <language>secrets</language>
+  <rules>
+    <rule>
+      <repositoryKey>secrets</repositoryKey>
+      <key>custom_secret_rule</key>
+      <type>VULNERABILITY</type>
+      <priority>CRITICAL</priority>
+      <name>IntelliJ should be forbidden</name>
+      <templateKey>S6784</templateKey>
+      <description>Eclipse rules!!</description>
+      <parameters>
+        <parameter>
+          <key>detectionSpecification</key>
+          <value>matching:
+            pattern: "IntelliJ"</value>
+        </parameter>
+      </parameters>
+    </rule>
+  </rules>
+</profile>

--- a/its/target-platforms/commons.target
+++ b/its/target-platforms/commons.target
@@ -120,7 +120,7 @@ DynamicImport-Package: *
 				<dependency>
 					<groupId>org.sonarsource.sonarqube</groupId>
 					<artifactId>sonar-ws</artifactId>
-					<version>6.7</version>
+					<version>9.9.0.65466</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
## Summary

In order to test custom secrets, the Sonar WS artifact had to be updated, with slight adjustments to some tests. Additionally, the move to SonarQube Enterprise from the orchestrator had to be done as the custom secrets are only available there.