### PR TITLE
SLE-857: Fix flaky ITs with SQ

### DIFF
--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/wizards/ProjectBindingWizard.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/wizards/ProjectBindingWizard.java
@@ -30,7 +30,7 @@ import org.eclipse.reddeer.swt.impl.text.DefaultText;
 
 public class ProjectBindingWizard extends WizardDialog {
   public ProjectBindingWizard() {
-    super(new DefaultShell());
+    super(new DefaultShell("Bind to a SonarQube or SonarCloud project"));
   }
 
   public static class BoundProjectsPage extends WizardPage {


### PR DESCRIPTION
Due to timing issues between the connection and binding wizard some tests were sporadically failing. This is the same for polluted logs.