### PR TITLE
SLE-924: Refactor standalone analysis ITs

### DIFF
--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/ConfirmManualAnalysisDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/ConfirmManualAnalysisDialogOpened.java
@@ -1,0 +1,55 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.conditions;
+
+import org.eclipse.reddeer.common.condition.WaitCondition;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ConfirmManualAnalysisDialog;
+
+public class ConfirmManualAnalysisDialogOpened implements WaitCondition {
+  @Override
+  public boolean test() {
+    try {
+      new ConfirmManualAnalysisDialog().isEnabled();
+      return true;
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  @Override
+  public ConfirmManualAnalysisDialog getResult() {
+    return new ConfirmManualAnalysisDialog();
+  }
+
+  @Override
+  public String description() {
+    return "Confirm manual analysis dialog is opened";
+  }
+
+  @Override
+  public String errorMessageWhile() {
+    return "Confirm manual analysis dialog is still opened";
+  }
+
+  @Override
+  public String errorMessageUntil() {
+    return "Confirm manual analysis dialog is not yet opened";
+  }
+}

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/EnhancedWithConnectedModeInformationDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/EnhancedWithConnectedModeInformationDialogOpened.java
@@ -1,0 +1,61 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.conditions;
+
+import org.eclipse.reddeer.common.condition.WaitCondition;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.EnhancedWithConnectedModeInformationDialog;
+
+public class EnhancedWithConnectedModeInformationDialogOpened implements WaitCondition {
+  private final String title;
+
+  public EnhancedWithConnectedModeInformationDialogOpened(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public boolean test() {
+    try {
+      new EnhancedWithConnectedModeInformationDialog(title).isEnabled();
+      return true;
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  @Override
+  public EnhancedWithConnectedModeInformationDialog getResult() {
+    return new EnhancedWithConnectedModeInformationDialog(title);
+  }
+
+  @Override
+  public String description() {
+    return "Enhanced with Connected Mode dialog is opened: " + title;
+  }
+
+  @Override
+  public String errorMessageWhile() {
+    return "Enhanced with Connected Mode dialog is still opened: " + title;
+  }
+
+  @Override
+  public String errorMessageUntil() {
+    return "Enhanced with Connected Mode dialog is not yet opened: " + title;
+  }
+}

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmManualAnalysisDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmManualAnalysisDialog.java
@@ -1,0 +1,34 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
+
+import org.eclipse.reddeer.swt.impl.button.OkButton;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+
+/** When manually big chunks of files / a project we currently display a confirmation dialog */
+public class ConfirmManualAnalysisDialog extends DefaultShell {
+  public ConfirmManualAnalysisDialog() {
+    super("Confirmation");
+  }
+
+  public void ok() {
+    new OkButton(this).click();
+  }
+}


### PR DESCRIPTION
[SLE-924](https://sonarsource.atlassian.net/browse/SLE-924)

All interactions with notifications and dialogs (shells) were not awaiting the shells to actually exist. This should now be fixed for all shells contributed by us. For the shells contributed by RedDeer itself (e.g., the project properties dialog), this is done on "their" side already.

Because all the implementations of `WaitCondition` are super big and mostly duplicated, I created a small task for the future (SLE-925) to de-duplicate it by creating a generic mother class. This is not part of this ticket, sprint, and release tho.

[SLE-924]: https://sonarsource.atlassian.net/browse/SLE-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ