### PR TITLE
SLE-923,SLE-927: Create ITs and incorporate validation feedback

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/AbstractSonarQubeConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/AbstractSonarQubeConnectedModeTest.java
@@ -40,7 +40,6 @@ import org.eclipse.swt.widgets.Label;
 import org.junit.Before;
 import org.osgi.framework.FrameworkUtil;
 import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
-import org.sonarlint.eclipse.its.shared.reddeer.conditions.AnalysisReadyAfterUnready;
 import org.sonarlint.eclipse.its.shared.reddeer.conditions.ProjectBindingWizardIsOpened;
 import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ProjectSelectionDialog;
 import org.sonarlint.eclipse.its.shared.reddeer.views.BindingsView;
@@ -206,10 +205,5 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
     serverProjectSelectionPage.waitForProjectsToBeFetched();
     serverProjectSelectionPage.setProjectKey(projectKey);
     projectBindingWizard.finish();
-  }
-
-  /** When binding project it will move to unready state before going to ready state again */
-  protected static void waitForAnalysisReady(String projectName) {
-    new WaitUntil(new AnalysisReadyAfterUnready(projectName), TimePeriod.getCustom(60));
   }
 }

--- a/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/OpenInIdeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/OpenInIdeTest.java
@@ -134,13 +134,13 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
 
     // 3) trigger "Open in IDE" feature, but cancel
     triggerOpenInIDE(orchestrator.getServer().getUrl(), branch.getName(), s101.getKey());
-    new WaitUntil(new ConfirmConnectionCreationDialogOpened(), TimePeriod.DEFAULT);
-    new ConfirmConnectionCreationDialog().donottrust();
+    new WaitUntil(new ConfirmConnectionCreationDialogOpened(false), TimePeriod.DEFAULT);
+    new ConfirmConnectionCreationDialog(false).donottrust();
 
     // 4) trigger "Open in IDE" feature, but accept this time
     triggerOpenInIDE(orchestrator.getServer().getUrl(), branch.getName(), s101.getKey());
-    new WaitUntil(new ConfirmConnectionCreationDialogOpened(), TimePeriod.DEFAULT);
-    new ConfirmConnectionCreationDialog().trust();
+    new WaitUntil(new ConfirmConnectionCreationDialogOpened(false), TimePeriod.DEFAULT);
+    new ConfirmConnectionCreationDialog(false).trust();
 
     var wizard = new ServerConnectionWizard();
     assertThat(new ServerConnectionWizard.ServerTypePage(wizard).isSonarQubeSelected()).isTrue();
@@ -217,8 +217,8 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
 
     // 3) trigger "Open in IDE" feature and accept
     triggerOpenInIDE(orchestrator.getServer().getUrl(), branch.getName(), s101.getKey(), tokenName, tokenValue);
-    new WaitUntil(new ConfirmConnectionCreationDialogOpened(), TimePeriod.DEFAULT);
-    new ConfirmConnectionCreationDialog().trust();
+    new WaitUntil(new ConfirmConnectionCreationDialogOpened(false), TimePeriod.DEFAULT);
+    new ConfirmConnectionCreationDialog(false).trust();
 
     // 4) await pop-up saying that automatic binding is not possible
     var popUp = new DefaultShell("SonarLint - No mathing open project found");
@@ -258,8 +258,8 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
 
     // 4) trigger "Open in IDE" feature, but cancel
     triggerOpenInIDE(orchestrator.getServer().getUrl(), branch.getName(), s101.getKey(), tokenName, tokenValue);
-    new WaitUntil(new ConfirmConnectionCreationDialogOpened(), TimePeriod.DEFAULT);
-    new ConfirmConnectionCreationDialog().donottrust();
+    new WaitUntil(new ConfirmConnectionCreationDialogOpened(false), TimePeriod.DEFAULT);
+    new ConfirmConnectionCreationDialog(false).donottrust();
 
     // 5) Check that token was revoked
     var userTokens = adminWsClient
@@ -276,8 +276,8 @@ public class OpenInIdeTest extends AbstractSonarQubeConnectedModeTest {
 
     // 7) trigger "Open in IDE" feature, but accept this time
     triggerOpenInIDE(orchestrator.getServer().getUrl(), branch.getName(), s101.getKey(), tokenName, tokenValue);
-    new WaitUntil(new ConfirmConnectionCreationDialogOpened(), TimePeriod.DEFAULT);
-    new ConfirmConnectionCreationDialog().trust();
+    new WaitUntil(new ConfirmConnectionCreationDialogOpened(false), TimePeriod.DEFAULT);
+    new ConfirmConnectionCreationDialog(false).trust();
 
     try {
       var projectSelectionDialog = new ProjectSelectionDialog();

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
@@ -76,6 +76,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Version;
 import org.osgi.service.prefs.BackingStoreException;
 import org.sonarlint.eclipse.its.shared.reddeer.conditions.AnalysisReady;
+import org.sonarlint.eclipse.its.shared.reddeer.conditions.AnalysisReadyAfterUnready;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.FileAssociationsPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.RuleConfigurationPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.SonarLintPreferences;
@@ -461,5 +462,10 @@ public abstract class AbstractSonarLintTest {
   /** On the these notifications the "content" is always the fourth label (index 3), don't ask me why! */
   protected static String getNotificationText(DefaultShell shell) {
     return new DefaultLabel(shell, 3).getText();
+  }
+
+  /** When binding project it will move to unready state before going to ready state again */
+  protected static void waitForAnalysisReady(String projectName) {
+    new WaitUntil(new AnalysisReadyAfterUnready(projectName), TimePeriod.getCustom(60));
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FileNotFoundDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FileNotFoundDialogOpened.java
@@ -17,23 +17,39 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
+package org.sonarlint.eclipse.its.shared.reddeer.conditions;
 
-import org.eclipse.reddeer.core.reference.ReferencedComposite;
-import org.eclipse.reddeer.swt.impl.button.PredefinedButton;
-import org.eclipse.swt.SWT;
+import org.eclipse.reddeer.common.condition.WaitCondition;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.FileNotFoundDialog;
 
-public class TrustButton extends PredefinedButton {
-  public TrustButton(ReferencedComposite referencedComposite, boolean isSonarCloud) {
-    this(referencedComposite, 0, isSonarCloud);
+public class FileNotFoundDialogOpened implements WaitCondition {
+  @Override
+  public boolean test() {
+    try {
+      new FileNotFoundDialog().isEnabled();
+      return true;
+    } catch (Exception ignored) {
+      return false;
+    }
   }
 
-  public TrustButton(ReferencedComposite referencedComposite, int index, boolean isSonarCloud) {
-    super(referencedComposite,
-      index,
-      isSonarCloud
-        ? "Connect to SonarCloud"
-        : "Connect to this SonarQube server",
-      SWT.PUSH);
+  @Override
+  public FileNotFoundDialog getResult() {
+    return new FileNotFoundDialog();
+  }
+
+  @Override
+  public String description() {
+    return "'File not found' dialog is opened";
+  }
+
+  @Override
+  public String errorMessageWhile() {
+    return "'File not found' dialog is still opened";
+  }
+
+  @Override
+  public String errorMessageUntil() {
+    return "'File not found' dialog is not yet opened";
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FixSuggestionAvailableDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FixSuggestionAvailableDialogOpened.java
@@ -20,19 +20,21 @@
 package org.sonarlint.eclipse.its.shared.reddeer.conditions;
 
 import org.eclipse.reddeer.common.condition.WaitCondition;
-import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ConfirmConnectionCreationDialog;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.FixSuggestionAvailableDialog;
 
-public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
-  private final boolean isSonarCloud;
+public class FixSuggestionAvailableDialogOpened implements WaitCondition {
+  private final int index;
+  private final int all;
 
-  public ConfirmConnectionCreationDialogOpened(boolean isSonarCloud) {
-    this.isSonarCloud = isSonarCloud;
+  public FixSuggestionAvailableDialogOpened(int index, int all) {
+    this.index = index;
+    this.all = all;
   }
 
   @Override
   public boolean test() {
     try {
-      new ConfirmConnectionCreationDialog(isSonarCloud).isEnabled();
+      new FixSuggestionAvailableDialog(index, all).isEnabled();
       return true;
     } catch (Exception ignored) {
       return false;
@@ -40,22 +42,22 @@ public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
   }
 
   @Override
-  public ConfirmConnectionCreationDialog getResult() {
-    return new ConfirmConnectionCreationDialog(isSonarCloud);
+  public FixSuggestionAvailableDialog getResult() {
+    return new FixSuggestionAvailableDialog(index, all);
   }
 
   @Override
   public String description() {
-    return "'Confirm Connection Creation' dialog is opened";
+    return "'Fix Suggestion (available)' dialog is opened";
   }
 
   @Override
   public String errorMessageWhile() {
-    return "'Confirm Connection Creation' dialog is still opened";
+    return "'Fix Suggestion (available)' dialog is still opened";
   }
 
   @Override
   public String errorMessageUntil() {
-    return "'Confirm Connection Creation' dialog is not yet opened";
+    return "'Fix Suggestion (available)' dialog is not yet opened";
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FixSuggestionUnavailableDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/FixSuggestionUnavailableDialogOpened.java
@@ -20,19 +20,21 @@
 package org.sonarlint.eclipse.its.shared.reddeer.conditions;
 
 import org.eclipse.reddeer.common.condition.WaitCondition;
-import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ConfirmConnectionCreationDialog;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.FixSuggestionUnavailableDialog;
 
-public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
-  private final boolean isSonarCloud;
+public class FixSuggestionUnavailableDialogOpened implements WaitCondition {
+  private final int index;
+  private final int all;
 
-  public ConfirmConnectionCreationDialogOpened(boolean isSonarCloud) {
-    this.isSonarCloud = isSonarCloud;
+  public FixSuggestionUnavailableDialogOpened(int index, int all) {
+    this.index = index;
+    this.all = all;
   }
 
   @Override
   public boolean test() {
     try {
-      new ConfirmConnectionCreationDialog(isSonarCloud).isEnabled();
+      new FixSuggestionUnavailableDialog(index, all).isEnabled();
       return true;
     } catch (Exception ignored) {
       return false;
@@ -40,22 +42,22 @@ public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
   }
 
   @Override
-  public ConfirmConnectionCreationDialog getResult() {
-    return new ConfirmConnectionCreationDialog(isSonarCloud);
+  public FixSuggestionUnavailableDialog getResult() {
+    return new FixSuggestionUnavailableDialog(index, all);
   }
 
   @Override
   public String description() {
-    return "'Confirm Connection Creation' dialog is opened";
+    return "'Fix Suggestion (unavailable)' dialog is opened";
   }
 
   @Override
   public String errorMessageWhile() {
-    return "'Confirm Connection Creation' dialog is still opened";
+    return "'Fix Suggestion (unavailable)' dialog is still opened";
   }
 
   @Override
   public String errorMessageUntil() {
-    return "'Confirm Connection Creation' dialog is not yet opened";
+    return "'Fix Suggestion (unavailable)' dialog is not yet opened";
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/ProjectSelectionDialogOpened.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/conditions/ProjectSelectionDialogOpened.java
@@ -20,19 +20,13 @@
 package org.sonarlint.eclipse.its.shared.reddeer.conditions;
 
 import org.eclipse.reddeer.common.condition.WaitCondition;
-import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ConfirmConnectionCreationDialog;
+import org.sonarlint.eclipse.its.shared.reddeer.dialogs.ProjectSelectionDialog;
 
-public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
-  private final boolean isSonarCloud;
-
-  public ConfirmConnectionCreationDialogOpened(boolean isSonarCloud) {
-    this.isSonarCloud = isSonarCloud;
-  }
-
+public class ProjectSelectionDialogOpened implements WaitCondition {
   @Override
   public boolean test() {
     try {
-      new ConfirmConnectionCreationDialog(isSonarCloud).isEnabled();
+      new ProjectSelectionDialog().isEnabled();
       return true;
     } catch (Exception ignored) {
       return false;
@@ -40,22 +34,22 @@ public class ConfirmConnectionCreationDialogOpened implements WaitCondition {
   }
 
   @Override
-  public ConfirmConnectionCreationDialog getResult() {
-    return new ConfirmConnectionCreationDialog(isSonarCloud);
+  public ProjectSelectionDialog getResult() {
+    return new ProjectSelectionDialog();
   }
 
   @Override
   public String description() {
-    return "'Confirm Connection Creation' dialog is opened";
+    return "'Project selection for binding' dialog is opened";
   }
 
   @Override
   public String errorMessageWhile() {
-    return "'Confirm Connection Creation' dialog is still opened";
+    return "'Project selection for binding' dialog is still opened";
   }
 
   @Override
   public String errorMessageUntil() {
-    return "'Confirm Connection Creation' dialog is not yet opened";
+    return "'Project selection for binding' dialog is not yet opened";
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmConnectionCreationDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmConnectionCreationDialog.java
@@ -26,7 +26,7 @@ public class ConfirmConnectionCreationDialog extends DefaultShell {
 
   public ConfirmConnectionCreationDialog(boolean isSonarCloud) {
     super(isSonarCloud
-      ? "Do you trust SonarCloud?"
+      ? "Do you trust this SonarCloud organization?"
       : "Do you trust this SonarQube server?");
     this.isSonarCloud = isSonarCloud;
   }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmConnectionCreationDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/ConfirmConnectionCreationDialog.java
@@ -22,12 +22,17 @@ package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 
 public class ConfirmConnectionCreationDialog extends DefaultShell {
-  public ConfirmConnectionCreationDialog() {
-    super("Do you trust this SonarQube server?");
+  private final boolean isSonarCloud;
+
+  public ConfirmConnectionCreationDialog(boolean isSonarCloud) {
+    super(isSonarCloud
+      ? "Do you trust SonarCloud?"
+      : "Do you trust this SonarQube server?");
+    this.isSonarCloud = isSonarCloud;
   }
 
   public void trust() {
-    new TrustButton(this).click();
+    new TrustButton(this, isSonarCloud).click();
   }
 
   public void donottrust() {

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FileNotFoundDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FileNotFoundDialog.java
@@ -19,21 +19,15 @@
  */
 package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
 
-import org.eclipse.reddeer.core.reference.ReferencedComposite;
-import org.eclipse.reddeer.swt.impl.button.PredefinedButton;
-import org.eclipse.swt.SWT;
+import org.eclipse.reddeer.swt.impl.button.OkButton;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 
-public class TrustButton extends PredefinedButton {
-  public TrustButton(ReferencedComposite referencedComposite, boolean isSonarCloud) {
-    this(referencedComposite, 0, isSonarCloud);
+public class FileNotFoundDialog extends DefaultShell {
+  public FileNotFoundDialog() {
+    super("File not found");
   }
 
-  public TrustButton(ReferencedComposite referencedComposite, int index, boolean isSonarCloud) {
-    super(referencedComposite,
-      index,
-      isSonarCloud
-        ? "Connect to SonarCloud"
-        : "Connect to this SonarQube server",
-      SWT.PUSH);
+  public void ok() {
+    new OkButton(this).click();
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FixSuggestionAvailableDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FixSuggestionAvailableDialog.java
@@ -1,0 +1,61 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2024 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
+
+import org.eclipse.reddeer.core.reference.ReferencedComposite;
+import org.eclipse.reddeer.swt.impl.button.PredefinedButton;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+import org.eclipse.swt.SWT;
+
+public class FixSuggestionAvailableDialog extends DefaultShell {
+  public FixSuggestionAvailableDialog(int index, int all) {
+    super(String.format("SonarLint Fix Suggestion (%d/%d)", index + 1, all));
+  }
+
+  public void applyTheChange() {
+    new ApplyTheChangeButton(this).click();
+  }
+
+  public void declineTheChange() {
+    new DeclineTheChangeButton(this).click();
+  }
+
+  public void cancel() {
+    new CancelButton(this).click();
+  }
+
+  private static class ApplyTheChangeButton extends PredefinedButton {
+    public ApplyTheChangeButton(ReferencedComposite referencedComposite) {
+      super(referencedComposite, 0, "Apply the change", SWT.PUSH);
+    }
+  }
+
+  private static class DeclineTheChangeButton extends PredefinedButton {
+    public DeclineTheChangeButton(ReferencedComposite referencedComposite) {
+      super(referencedComposite, 0, "Decline the change", SWT.PUSH);
+    }
+  }
+
+  private static class CancelButton extends PredefinedButton {
+    public CancelButton(ReferencedComposite referencedComposite) {
+      super(referencedComposite, 0, "Cancel", SWT.PUSH);
+    }
+  }
+}

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FixSuggestionUnavailableDialog.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/dialogs/FixSuggestionUnavailableDialog.java
@@ -21,19 +21,31 @@ package org.sonarlint.eclipse.its.shared.reddeer.dialogs;
 
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
 import org.eclipse.reddeer.swt.impl.button.PredefinedButton;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.swt.SWT;
 
-public class TrustButton extends PredefinedButton {
-  public TrustButton(ReferencedComposite referencedComposite, boolean isSonarCloud) {
-    this(referencedComposite, 0, isSonarCloud);
+public class FixSuggestionUnavailableDialog extends DefaultShell {
+  public FixSuggestionUnavailableDialog(int index, int all) {
+    super(String.format("SonarLint Fix Suggestion (%d/%d)", index + 1, all));
   }
 
-  public TrustButton(ReferencedComposite referencedComposite, int index, boolean isSonarCloud) {
-    super(referencedComposite,
-      index,
-      isSonarCloud
-        ? "Connect to SonarCloud"
-        : "Connect to this SonarQube server",
-      SWT.PUSH);
+  public void proceed() {
+    new ProceedButton(this).click();
+  }
+
+  public void cancel() {
+    new CancelButton(this).click();
+  }
+
+  private static class ProceedButton extends PredefinedButton {
+    public ProceedButton(ReferencedComposite referencedComposite) {
+      super(referencedComposite, 0, "Proceed", SWT.PUSH);
+    }
+  }
+
+  private static class CancelButton extends PredefinedButton {
+    public CancelButton(ReferencedComposite referencedComposite) {
+      super(referencedComposite, 0, "Cancel", SWT.PUSH);
+    }
   }
 }

--- a/its/projects/connected-sc/sonarlint-its-sample-java-issues/.project
+++ b/its/projects/connected-sc/sonarlint-its-sample-java-issues/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sonarlint-its-sample-java-issues</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/its/projects/connected-sc/sonarlint-its-sample-java-issues/FileExists.txt
+++ b/its/projects/connected-sc/sonarlint-its-sample-java-issues/FileExists.txt
@@ -1,0 +1,1 @@
+Eclipse IDE is the best!

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarCloudConnectionCreationDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/assist/ConfirmSonarCloudConnectionCreationDialog.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Shell;
 public class ConfirmSonarCloudConnectionCreationDialog extends AbstractConfirmConnectionCreationDialog {
   public ConfirmSonarCloudConnectionCreationDialog(Shell parentShell, String organization, boolean automaticSetUp) {
     super(parentShell,
-      "Do you trust SonarCloud?",
+      "Do you trust this SonarCloud organization?",
       "SonarCloud is attempting to set up a connection for the organization '" + organization + "' with SonarLint.",
       "Connect to SonarCloud",
       automaticSetUp);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/FixSuggestionAvailableDialog.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/dialog/FixSuggestionAvailableDialog.java
@@ -33,17 +33,17 @@ public class FixSuggestionAvailableDialog extends AbstractFixSuggestionDialog {
   }
 
   /**
-   *  "Apply Changes"   -> applies the change and moves on to the next one
-   *  "Decline Changes" -> does not apply the change, but moves on to the next one
-   *  "Cancel"          -> cancels the whole process, nothing will be further applied
+   *  "Apply the change"   -> applies the change and moves on to the next one
+   *  "Decline the change" -> does not apply the change, but moves on to the next one
+   *  "Cancel"             -> cancels the whole process, nothing will be further applied
    *
    *  The order is based on how it will be displayed in dialog. The first one is always the most right one (because of
    *  the "true") and the others are aligned to its left from left to right!
    */
   @Override
   protected void createButtonsForButtonBar(Composite parent) {
-    createButton(parent, IDialogConstants.OK_ID, "Apply Changes", true);
+    createButton(parent, IDialogConstants.OK_ID, "Apply the change", true);
     createButton(parent, IDialogConstants.CANCEL_ID, "Cancel", false);
-    createButton(parent, IDialogConstants.SKIP_ID, "Decline Changes", false);
+    createButton(parent, IDialogConstants.SKIP_ID, "Decline the change", false);
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/AbstractOpenInEclipseJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/AbstractOpenInEclipseJob.java
@@ -101,8 +101,8 @@ public abstract class AbstractOpenInEclipseJob extends Job {
       var status = statusRef.get();
       if (Status.CANCEL_STATUS == status) {
         if (cancelledByJob.get()) {
-          MessageDialogUtils.openInIdeError("The previous dialog was closed either manually by you or the connection was not ready in "
-            + "time. The reason for the latter could be a slow network connection.");
+          MessageDialogUtils.dialogCancelled("The previous dialog was closed either manually by you or the connection "
+            + "was not ready in time. The reason for the latter could be a slow network connection.");
         }
         return status;
       }
@@ -132,7 +132,7 @@ public abstract class AbstractOpenInEclipseJob extends Job {
       actualRun();
     } catch (CoreException e) {
       var message = "An error occured while trying to run the requested action.";
-      MessageDialogUtils.openInIdeError(message + " Please see the console for the full error log!");
+      MessageDialogUtils.openInEclipseFailed(message + " Please see the console for the full error log!");
       SonarLintLogger.get().error(message, e);
     }
 
@@ -150,7 +150,7 @@ public abstract class AbstractOpenInEclipseJob extends Job {
     // Check if file exists in project based on the server to IDE path matching
     var fileOpt = project.find(getIdeFilePath());
     if (fileOpt.isEmpty()) {
-      MessageDialogUtils.openInIdeError("The required file cannot be found in the project '"
+      MessageDialogUtils.fileNotFound("The required file cannot be found in the project '"
         + project.getName() + "'. Maybe it was already changed locally!");
       return Optional.empty();
     }
@@ -186,10 +186,10 @@ public abstract class AbstractOpenInEclipseJob extends Job {
 
     if (localBranch.isEmpty()) {
       // This error message may be misleading to COBOL / ABAP developers but that is okay for now :>
-      MessageDialogUtils.openInIdeInformation("The local branch of the project '" + project.getName()
+      MessageDialogUtils.branchNotAvailable("The local branch of the project '" + project.getName()
         + "' could not be determined. SonarLint now can only try to find the matching local issue!");
     } else if (!branch.equals(localBranch.get())) {
-      MessageDialogUtils.openInIdeError("The local branch '" + localBranch.get() + "' of the project '"
+      MessageDialogUtils.branchMismatch("The local branch '" + localBranch.get() + "' of the project '"
         + project.getName() + "' does not match the remote branch '" + branch + "'. "
         + "Please checkout the correct branch and invoke the requested action once again!");
       BrowserUtils.openExternalBrowser(SonarLintDocumentation.BRANCH_AWARENESS, Display.getDefault());

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/OpenIssueInEclipseJob.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/job/OpenIssueInEclipseJob.java
@@ -150,7 +150,7 @@ public class OpenIssueInEclipseJob extends AbstractOpenInEclipseJob {
           new OpenIssueInEclipseJob(new OpenIssueContext(name, issueDetails, project, binding, file, true))
             .schedule(1000);
         } else {
-          MessageDialogUtils.openInIdeError("Fetching the issue to be displayed failed because the dependent "
+          MessageDialogUtils.openInEclipseFailed("Fetching the issue to be displayed failed because the dependent "
             + "job did not finish successfully.");
         }
       }
@@ -162,7 +162,7 @@ public class OpenIssueInEclipseJob extends AbstractOpenInEclipseJob {
     // When we already asked the user to change his workspace preferences, he agreed but did not change anything we
     // don't want to end up in a loop asking the user if could please change his preferences ^^
     if (askedForPreferenceChangeAlready) {
-      MessageDialogUtils.openInIdeError("The issue was not found locally. Maybe the issue was already "
+      MessageDialogUtils.openInEclipseFailed("The issue was not found locally. Maybe the issue was already "
         + "resolved or the resources has moved / was deleted.");
       return Status.CANCEL_STATUS;
     }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
@@ -28,29 +28,41 @@ import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 
 /** When we want to display simple dialogs we can use the JFace MessageDialog */
 public class MessageDialogUtils {
-  private static final String OPEN_IN_IDE_TITLE = "Open in IDE";
-
   private MessageDialogUtils() {
     // utility class
   }
 
-  /** For the "Open in IDE" feature we want to display an information */
-  public static void openInIdeInformation(String message) {
-    Display.getDefault().syncExec(() -> MessageDialog.openInformation(
-      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), OPEN_IN_IDE_TITLE, message));
+  private static void showError(String title, String message) {
+    Display.getDefault().syncExec(() -> MessageDialog.openError(
+      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), title, message));
   }
 
-  /** For the "Open in IDE" feature we want to display an error message */
-  public static void openInIdeError(String message) {
-    Display.getDefault().syncExec(() -> MessageDialog.openError(
-      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), OPEN_IN_IDE_TITLE, message));
+  public static void fileNotFound(String message) {
+    showError("File not found", message);
+  }
+
+  public static void dialogCancelled(String message) {
+    showError("Dialog cancelled", message);
+  }
+
+  public static void branchMismatch(String message) {
+    showError("Branch not matching", message);
+  }
+
+  public static void openInEclipseFailed(String message) {
+    showError("Open in Eclipse failed", message);
+  }
+
+  public static void branchNotAvailable(String message) {
+    Display.getDefault().syncExec(() -> MessageDialog.openInformation(
+      PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Branch not matchable", message));
   }
 
   /** For the "Open in IDE" feature we want to display a yes/no question for the user to answer */
   public static void openInIdeQuestion(String message, Runnable yesHandler) {
     Display.getDefault().asyncExec(() -> {
       var result = MessageDialog.openQuestion(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
-        OPEN_IN_IDE_TITLE, message);
+        "Open in IDE", message);
       if (result) {
         yesHandler.run();
       }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/MessageDialogUtils.java
@@ -46,7 +46,7 @@ public class MessageDialogUtils {
   }
 
   public static void branchMismatch(String message) {
-    showError("Branch not matching", message);
+    showError("Branch does not match", message);
   }
 
   public static void openInEclipseFailed(String message) {

--- a/target-platforms/dev.target
+++ b/target-platforms/dev.target
@@ -3,7 +3,7 @@
 <target name="sonarlint-eclipse-dev" sequenceNumber="2">
   <locations>
     <location type="Target" uri="file:${project_loc:/org.sonarlint.eclipse.its}/../target-platforms/commons-build.target" />
-    <location type="Target" uri="file:${project_loc:/org.sonarlint.eclipse.its}/../target-platforms/latest-java-17_e431.target" />
+    <location type="Target" uri="file:${project_loc:/org.sonarlint.eclipse.its}/../target-platforms/latest-java-21.target" />
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11" />
 </target>


### PR DESCRIPTION
## Changes to the `dev` target platform

In order to run RedDeer tests from the latest Eclipse IDE (that is running on top of Java 21), we also now have to use the Java 21-based Eclipse IDE as a reference in our development environment. I didn't notice it before as I developed against a dogfooding version of the Eclipse IDE that was powered by my locally installed Java 17 runtime.

## SLE-927: Validation feedback

Feedback from the PM was incorporated before implementing the ITs. To make it clearer, what was meant with button descriptions and notification titles displayed on failure. See the commit messages for more information.

## SLE-923: Integration tests

A set of integration tests covering most of the cases by emulating a call from SonarCloud to the internal endpoint of SonarLint. This includes the default `file not found` as well as canceling, declining, and applying changes as well as already implemented fixes - therefore, the suggestion could not be found.