### PR TITLE
SLE-926: macOS support for running in shell

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sc/pom.xml
+++ b/its/org.sonarlint.eclipse.its.connected.sc/pom.xml
@@ -36,26 +36,19 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
+          <!--
+            Since we use product files for the runtime configuration we have to configure SonarCloud URLs before the
+            IDE starts in order to hand it over to the RPC server of SLCORE.
+          -->
+          <systemProperties>
+            <sonarlint.internal.sonarcloud.url>https://sc-staging.io</sonarlint.internal.sonarcloud.url>
+          	<sonarlint.internal.sonarcloud.websocket.url>wss://events-api.sc-staging.io/</sonarlint.internal.sonarcloud.websocket.url>
+          </systemProperties>
           <install>
             <iu>
               <id>org.sonarlint.eclipse.its.connected.sc.product</id>
             </iu>
           </install>
-        </configuration>
-      </plugin>
-      
-      <!--
-        Since we use product files for the runtime configuration we have to configure SonarCloud URLs before the IDE
-        starts in order to hand it over to the RPC server of SLCORE.
-      -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <sonarlint.internal.sonarcloud.url>https://sc-staging.io</sonarlint.internal.sonarcloud.url>
-          	<sonarlint.internal.sonarcloud.websocket.url>wss://events-api.sc-staging.io/</sonarlint.internal.sonarcloud.websocket.url>
-          </systemProperties>
         </configuration>
       </plugin>
     </plugins>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -292,5 +292,26 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Used on macOS in order to be able to run ITs when Maven invoked from terminal -->
+    <profile>
+      <id>macOS-its</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-XstartOnFirstThread</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/org.sonarlint.eclipse.core.tests/pom.xml
+++ b/org.sonarlint.eclipse.core.tests/pom.xml
@@ -105,6 +105,26 @@
         </plugins>
       </build>
     </profile>
-  </profiles>
 
+    <!-- Used on macOS in order to be able to run UTs when Maven invoked from terminal -->
+    <profile>
+      <id>macOS-uts</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-XstartOnFirstThread</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
[SLE-926](https://sonarsource.atlassian.net/browse/SLE-926)

When running on macOS, we have to add a specific argument to make it usable, e.g., when running UTs/ITs on the command line. Noticed when running with Sophio that we had to adjust it all the time on her side.

[SLE-926]: https://sonarsource.atlassian.net/browse/SLE-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ