### PR TITLE
SLE-937: Cirrus CI build relies on mirrord PyDev

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -128,6 +128,8 @@ build_task:
   codesigning_file:
     path: ${SM_CLIENT_CERT_FILE}.b64
     variable_name: SM_CLIENT_CERT_FILE_BASE64
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   build_script: |
     base64 --decode "${SM_CLIENT_CERT_FILE}.b64" > "${SM_CLIENT_CERT_FILE}"
@@ -154,6 +156,8 @@ validate_task:
   env:
     DEPLOY_PULL_REQUEST: false
     DISPLAY: :10
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   xvfb_background_script: |
     /etc/init.d/xvfb start
@@ -206,6 +210,8 @@ qa_connectedModeSonarQube_task:
     - env:
         SQ_VERSION: 'DEV'
         QA_CATEGORY: 'DEV'
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE_QA
   <<: *SETUP_ORCHESTRATOR_CACHE
   download_staged_update_site_script: |
@@ -274,6 +280,8 @@ qa_connectedModeSonarCloud_task:
     SONARCLOUD_IT_PASSWORD: VAULT[development/team/sonarlint/kv/data/sonarcloud-it data.password]
     DISPLAY: :10
     MAVEN_OPTS: -Xmx3072m
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE_QA
   download_staged_update_site_script: |
     set -euo pipefail
@@ -347,6 +355,8 @@ qa_standaloneMode_task:
         TARGET_PLATFORM: 'latest-java-17_e431'
     - env:
         TARGET_PLATFORM: 'latest-java-21'
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE_QA
   download_staged_update_site_script: |
     set -euo pipefail
@@ -428,6 +438,8 @@ sonarqube_task:
   env:
     DEPLOY_PULL_REQUEST: false
     DISPLAY: :10
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   prepare_background_script: |
     set -euo pipefail
@@ -469,6 +481,8 @@ mend_scan_task:
     type: m6a.large
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   whitesource_script:
     - source cirrus-env QA
@@ -497,6 +511,8 @@ promote_task:
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   promote_script: |
     .cirrus/cirrus_promote_maven

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -54,6 +54,8 @@ qa_ibuilds_task:
     GITHUB_TOKEN: VAULT[development/github/token/licenses-ro token]
     DISPLAY: :10
     MAVEN_OPTS: -Xmx3072m
+  pydev_update_sites_script: |
+    source .cirrus/pydev_update_sites
   <<: *SETUP_MAVEN_CACHE
   prepare_update_site_script: |
     set -euo pipefail

--- a/.cirrus/pydev_update_sites
+++ b/.cirrus/pydev_update_sites
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script to change the PyDev Eclipse Sites to our internal mirrors in order to not fail on these
+# ones as they are super flaky on Cirrus CI from time to time!
+# INFO: When updating this, also update the actual target platforms!
+
+sed -i 's#https://www.pydev.org/update_sites/6.0.0/#https://repox.jfrog.io/artifactory/pydev-p2-6_0_0/#g' \
+  target-platforms/oldest-java-11_e48.target
+
+sed -i 's#https://www.pydev.org/update_sites/10.2.1/#https://repox.jfrog.io/artifactory/pydev-p2-10_2_1/#g' \
+  target-platforms/latest-java-11_e424.target
+
+sed -i 's#https://www.pydev.org/update_sites/12.0.0/#https://repox.jfrog.io/artifactory/pydev-p2-12_0_0/#g' \
+  target-platforms/latest-java-17_e431.target
+
+sed -i 's#https://www.pydev.org/update_sites/12.1.0/#https://repox.jfrog.io/artifactory/pydev-p2-12_1_0/#g' \
+  target-platforms/latest-java-21.target

--- a/target-platforms/latest-java-11_e424.target
+++ b/target-platforms/latest-java-11_e424.target
@@ -23,9 +23,10 @@
     <!-- INFO: Here we don't reference "org.sonarlint.eclipse.its" project as Maven won't find it! -->
     <location type="Target" uri="file:${project_loc:/sonarlint-eclipse-parent}/target-platforms/commons-build.target"/>
     
+    <!-- INFO: When updating this, also update the script at ".cirrus/pydev_update_sites"! -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="https://www.pydev.org/update_sites/10.2.1" />
+      <repository location="https://www.pydev.org/update_sites/10.2.1/" />
     </location>
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/target-platforms/latest-java-17_e431.target
+++ b/target-platforms/latest-java-17_e431.target
@@ -29,9 +29,10 @@
       <repository location="https://download.eclipse.org/mylyn/updates/release/" />
     </location>
     
+    <!-- INFO: When updating this, also update the script at ".cirrus/pydev_update_sites"! -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="https://www.pydev.org/update_sites/12.0.0" />
+      <repository location="https://www.pydev.org/update_sites/12.0.0/" />
     </location>
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/target-platforms/latest-java-21.target
+++ b/target-platforms/latest-java-21.target
@@ -36,9 +36,10 @@
       <repository location="https://download.eclipse.org/mylyn/updates/release/" />
     </location>
     
+    <!-- INFO: When updating this, also update the script at ".cirrus/pydev_update_sites"! -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
-      <repository location="https://www.pydev.org/update_sites/12.1.0" />
+      <repository location="https://www.pydev.org/update_sites/12.1.0/" />
     </location>
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/target-platforms/oldest-java-11_e48.target
+++ b/target-platforms/oldest-java-11_e48.target
@@ -24,6 +24,7 @@
       <repository location="https://download.eclipse.org/reddeer/releases/4.2.0/" />
     </location>
     
+    <!-- INFO: When updating this, also update the script at ".cirrus/pydev_update_sites"! -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0" />
       <repository location="https://www.pydev.org/update_sites/6.0.0/" />


### PR DESCRIPTION
[SLE-937](https://sonarsource.atlassian.net/browse/SLE-937)

The Eclipse Update Sites of PyDev are just too flaky, therefore we have our own mirrors that should be more reliable!

[SLE-937]: https://sonarsource.atlassian.net/browse/SLE-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ