### PR TITLE
SLE-930: Narrow down focus on CDT projects

### DIFF
--- a/org.sonarlint.eclipse.cdt/plugin.xml
+++ b/org.sonarlint.eclipse.cdt/plugin.xml
@@ -13,6 +13,12 @@
         </provider>
      </extension>
      <extension
+         point="org.sonarlint.eclipse.core.projectScopeProvider">
+      <provider
+            class="org.sonarlint.eclipse.cdt.internal.CProjectConfiguratorExtension">
+      </provider>
+   </extension>
+     <extension
          point="org.sonarlint.eclipse.ui.syntaxHighlightingProvider">
       <enhancer
             class="org.sonarlint.eclipse.cdt.internal.CProjectConfiguratorExtension">

--- a/org.sonarlint.eclipse.cdt/src/org/sonarlint/eclipse/cdt/internal/CProjectConfiguratorExtension.java
+++ b/org.sonarlint.eclipse.cdt/src/org/sonarlint/eclipse/cdt/internal/CProjectConfiguratorExtension.java
@@ -23,24 +23,22 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
-import org.eclipse.cdt.core.CCProjectNature;
-import org.eclipse.cdt.core.CProjectNature;
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorPart;
-import org.sonarlint.eclipse.core.SonarLintLogger;
 import org.sonarlint.eclipse.core.analysis.IAnalysisConfigurator;
 import org.sonarlint.eclipse.core.analysis.IFileLanguageProvider;
 import org.sonarlint.eclipse.core.analysis.IPreAnalysisContext;
 import org.sonarlint.eclipse.core.analysis.SonarLintLanguage;
+import org.sonarlint.eclipse.core.resource.IProjectScopeProvider;
 import org.sonarlint.eclipse.core.resource.ISonarLintFile;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.rule.ISyntaxHighlightingProvider;
@@ -48,7 +46,8 @@ import org.sonarlint.eclipse.ui.rule.ISyntaxHighlightingProvider;
 /**
  * Responsible for checking at runtime if CDT plugin is installed.
  */
-public class CProjectConfiguratorExtension implements IAnalysisConfigurator, IFileLanguageProvider, ISyntaxHighlightingProvider {
+public class CProjectConfiguratorExtension implements IAnalysisConfigurator, IFileLanguageProvider,
+  IProjectScopeProvider, ISyntaxHighlightingProvider {
 
   private static final String CPP_LANGUAGE_KEY = "cpp";
   private static final String C_LANGUAGE_KEY = "c";
@@ -85,16 +84,8 @@ public class CProjectConfiguratorExtension implements IAnalysisConfigurator, IFi
 
   @Override
   public boolean canConfigure(ISonarLintProject project) {
-    try {
-      var underlyingProject = project.getResource() instanceof IProject ? (IProject) project.getResource() : null;
-      // Constants are inlined so this should not cause ClassNotFound
-      return cdtUtils != null &&
-        underlyingProject != null &&
-        (underlyingProject.hasNature(CProjectNature.C_NATURE_ID) || underlyingProject.hasNature(CCProjectNature.CC_NATURE_ID));
-    } catch (CoreException e) {
-      SonarLintLogger.get().error(e.getMessage(), e);
-      return false;
-    }
+    var iProject = project.getResource() instanceof IProject ? (IProject) project.getResource() : null;
+    return cdtUtils != null && iProject != null && cdtUtils.hasCOrCppNature(iProject);
   }
 
   @Override
@@ -151,5 +142,12 @@ public class CProjectConfiguratorExtension implements IAnalysisConfigurator, IFi
     return canProvideUiElements(ruleLanguage)
       ? CdtUiUtils.getTextMergeViewer(parent, mp)
       : null;
+  }
+
+  @Override
+  public Set<IPath> getExclusions(IProject project) {
+    return cdtUtils != null && cdtUtils.hasCOrCppNature(project)
+      ? cdtUtils.getExcludedPaths(project)
+      : Collections.emptySet();
   }
 }


### PR DESCRIPTION
[SLE-930](https://sonarsource.atlassian.net/browse/SLE-930)

When working with CDT projects we don't want SonarLint to index the output directories containing the compiled source and possible generated Makefiles.

[SLE-930]: https://sonarsource.atlassian.net/browse/SLE-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ