### PR TITLE
SLE-855: Rely on mirrored PyDev

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -132,6 +132,7 @@ build_task:
   build_script: |
     base64 --decode "${SM_CLIENT_CERT_FILE}.b64" > "${SM_CLIENT_CERT_FILE}"
     source cirrus-env BUILD-PRIVATE
+    .cirrus/mirrored_update_sites
     .cirrus/regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dsonar.skip=true -Dcyclonedx.skip=false
   site_artifacts:
     paths: org.sonarlint.eclipse.site/target/org.sonarlint.eclipse.site-*.zip
@@ -161,6 +162,7 @@ validate_task:
     metacity --sm-disable --replace &
     sleep 10 # give metacity some time to start
     source cirrus-env QA
+    .cirrus/mirrored_update_sites
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify -Pcoverage \
       -Djacoco.append=true -Djacoco.destFile=${CIRRUS_WORKING_DIR}/ut-coverage.exec
     /etc/init.d/xvfb stop
@@ -222,6 +224,7 @@ qa_connectedModeSonarQube_task:
     ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${QA_CATEGORY}.mp4
   run_its_script: |
     echo "Run Maven ITs for Connected Mode with SonarQube on Eclipse 2024-03 / 4.31 (latest Java 17) and Server ${SQ_VERSION}"
+    .cirrus/mirrored_update_sites
     cd its/
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify \
       -P coverage,\!standaloneMode,\!connectedModeSc \
@@ -289,6 +292,7 @@ qa_connectedModeSonarCloud_task:
     ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording.mp4
   run_its_script: |
     echo "Run Maven ITs for Connected Mode with SonarCloud on Eclipse (latest Java 21)"
+    .cirrus/mirrored_update_sites
     cd its/
     env SONARCLOUD_IT_PASSWORD=$SONARCLOUD_IT_PASSWORD \
       mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify \
@@ -362,6 +366,7 @@ qa_standaloneMode_task:
     ffmpeg -loglevel warning -f x11grab -video_size 1920x1080 -i ${DISPLAY} -codec:v libx264 -r 12 ${CIRRUS_WORKING_DIR}/recording_${TARGET_PLATFORM}.mp4
   run_its_script: |
     echo "Run Maven ITs for Standalone Mode on Eclipse '${TARGET_PLATFORM}'"
+    .cirrus/mirrored_update_sites
     cd its/
     mvn -B -e -V org.jacoco:jacoco-maven-plugin:prepare-agent verify \
       -P coverage,\!connectedModeSq,\!connectedModeSc \
@@ -446,6 +451,7 @@ sonarqube_task:
     unzip jacoco_it_sq.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
     unzip jacoco_it_sc.zip -d ${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/
     source cirrus-env QA
+    .cirrus/mirrored_update_sites
     .cirrus/regular_mvn_build_deploy_analyze \
       -P-deploy-sonarsource,-release,-sign -Dmaven.install.skip=true -DskipTests -Dmaven.deploy.skip=true \
       -Pcoverage -Djacoco.append=true -Dsonar.coverage.jacoco.xmlReportPaths=${CIRRUS_WORKING_DIR}/org.sonarlint.eclipse.core.tests/target/site/jacoco-aggregate/jacoco.xml
@@ -472,6 +478,7 @@ mend_scan_task:
   <<: *SETUP_MAVEN_CACHE
   whitesource_script:
     - source cirrus-env QA
+    - .cirrus/mirrored_update_sites
     - source .cirrus/set_maven_build_version $BUILD_NUMBER
     - mvn -B -e -V clean install -DskipTests -Dcyclonedx.skip=false
     - source ws_scan.sh

--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -131,7 +131,7 @@ build_task:
   <<: *SETUP_MAVEN_CACHE
   build_script: |
     base64 --decode "${SM_CLIENT_CERT_FILE}.b64" > "${SM_CLIENT_CERT_FILE}"
-    source cirrus-env BUILD-BUILD
+    source cirrus-env BUILD
     .cirrus/mirrored_update_sites
     .cirrus/regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dsonar.skip=true -Dcyclonedx.skip=false
   site_artifacts:

--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -131,7 +131,7 @@ build_task:
   <<: *SETUP_MAVEN_CACHE
   build_script: |
     base64 --decode "${SM_CLIENT_CERT_FILE}.b64" > "${SM_CLIENT_CERT_FILE}"
-    source cirrus-env BUILD-PRIVATE
+    source cirrus-env BUILD-BUILD
     .cirrus/mirrored_update_sites
     .cirrus/regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dsonar.skip=true -Dcyclonedx.skip=false
   site_artifacts:

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -58,6 +58,7 @@ qa_ibuilds_task:
   prepare_update_site_script: |
     set -euo pipefail
     source cirrus-env QA
+    .cirrus/mirrored_update_sites
     source .cirrus/set_maven_build_version "$BUILD_NUMBER"
     mvn -B -e -V package
   prepare_background_script: |

--- a/.cirrus/mirrored_update_sites
+++ b/.cirrus/mirrored_update_sites
@@ -10,7 +10,7 @@
 #   https://repox.jfrog.io/ui/repos/tree/General/pydev-p2-{Major}_{Minor}_{Patch}
 PYDEV_REGEX_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
 PYDEV_REGEX_LINK="http[s]*:\/\/www\.pydev\.org\/update_sites\/$PYDEV_REGEX_VERSION"
-PYDEV_TEMPLATE_LINK="https://repox.jfrog.io/artifactory/pydev-p2-VERSION/"
+PYDEV_TEMPLATE_LINK="https://repox.jfrog.io/artifactory/pydev-p2-VERSION"
 
 
 # =================================================================================================

--- a/.cirrus/mirrored_update_sites
+++ b/.cirrus/mirrored_update_sites
@@ -10,7 +10,7 @@
 #   https://repox.jfrog.io/ui/repos/tree/General/pydev-p2-{Major}_{Minor}_{Patch}
 PYDEV_REGEX_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
 PYDEV_REGEX_LINK="http[s]*:\/\/www\.pydev\.org\/update_sites\/$PYDEV_REGEX_VERSION"
-PYDEV_TEMPLATE_LINK="https://repox.jfrog.io/artifactory/pydev-p2-VERSION"
+PYDEV_TEMPLATE_LINK="https://repox.jfrog.io/artifactory/pydev-p2-VERSION/"
 
 
 # =================================================================================================

--- a/.cirrus/mirrored_update_sites
+++ b/.cirrus/mirrored_update_sites
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# =================================================================================================
+#     mirrored_update_sites: Replace external Eclipse Update sites with mirrored ones on Repox
+# =================================================================================================
+
+# PyDev Eclipse Update site always lookd like this
+#   https://www.pydev.org/update_sites/{Major}.{Minor}.{Patch}
+# Mirrored link always looks like this
+#   https://repox.jfrog.io/ui/repos/tree/General/pydev-p2-{Major}_{Minor}_{Patch}
+PYDEV_REGEX_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
+PYDEV_REGEX_LINK="http[s]*:\/\/www\.pydev\.org\/update_sites\/$PYDEV_REGEX_VERSION"
+PYDEV_TEMPLATE_LINK="https://repox.jfrog.io/artifactory/pydev-p2-VERSION/"
+
+
+# =================================================================================================
+#   1) Check all target platforms that are provided for both Maven and Eclipse PDE
+# =================================================================================================
+
+TARGET_PLATFORMS=(target-platforms/*.target)
+
+
+# =================================================================================================
+#   2) Check for PyDev in file and replace with mirrored link on Repox
+# =================================================================================================
+
+for target_platform in "${TARGET_PLATFORMS[@]}"; do
+    PYDEV_LINK="$(grep -oP "$PYDEV_REGEX_LINK" $target_platform)"
+    if [[ -z ${PYDEV_LINK} ]]; then
+        echo "'$target_platform': No PyDev reference found"
+        continue
+    fi
+    PYDEV_VERSION="$(grep -oP "$PYDEV_REGEX_VERSION" <<< "$PYDEV_LINK")"
+
+    PYDEV_ADJUSTED_VERSION="${PYDEV_VERSION//./_}"
+    PYDEV_ADJUSTED_LINK="${PYDEV_TEMPLATE_LINK//VERSION/$PYDEV_ADJUSTED_VERSION}"
+
+    sed -i "s#$PYDEV_LINK#$PYDEV_ADJUSTED_LINK#" $target_platform
+    echo "'$target_platform': replaced '$PYDEV_LINK' with '$PYDEV_ADJUSTED_LINK'"
+done


### PR DESCRIPTION
[SLE-855](https://sonarsource.atlassian.net/browse/SLE-855)

For Cirrus CI rely on the mirrored PyDev Eclipse Update site in order to stabilize the build. The issue is not present locally and if it occurs, Maven can just be called again.