### PR TITLE
SLE-945: Enable test with RSE again

### DIFF
--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
@@ -488,7 +488,6 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
 
   // Need RSE
   @Test
-  @Ignore("09/2024: SLCORE checks on Symlinks are not working with RSE")
   @Category(RequiresExtraDependency.class)
   public void shouldAnalyseVirtualProject() throws Exception {
     // INFO: It is flaky when running on top of the oldest Eclipse version but works fine in the other test cases,


### PR DESCRIPTION
[SLE-945](https://sonarsource.atlassian.net/browse/SLE-945)

This test was disabled following a faulty implementation regarding the check of symlinks and missing implementation regarding Windows shortcuts in SLCORE.

[SLE-945]: https://sonarsource.atlassian.net/browse/SLE-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ