### PR TITLE
SLE-963: Log more on indexing exclusions and exclude base for CDT

### DIFF
--- a/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
+++ b/org.sonarlint.eclipse.jdt/src/org/sonarlint/eclipse/jdt/internal/JdtUtils.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -388,6 +389,10 @@ public class JdtUtils {
       SonarLintLogger.get().traceIdeMessage("Cannot get outputs for exclusions of project '"
         + project.getName() + "' based on JDT!", err);
     }
+
+    SonarLintLogger.get().traceIdeMessage("[JdtUtils#getExcludedPaths] The following paths have been excluded from "
+      + "indexing for the project at '" + project.getFullPath().makeAbsolute().toOSString() + "': "
+      + String.join(", ", exclusions.stream().map(Object::toString).collect(Collectors.toList())));
 
     return exclusions;
   }


### PR DESCRIPTION
[SLE-963](https://sonarsource.atlassian.net/browse/SLE-963)

Create a trace for the specific exclusions of JDT, Maven and Gradle (Eclipse Buildship) as well as CDT. This makes debugging easier.

For CDT also exclude the base directory and log on every configuration for every output directory as well.

[SLE-963]: https://sonarsource.atlassian.net/browse/SLE-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ