### PR TITLE
SLE-967: Users can opt-out of indexing support

### DIFF
--- a/its/projects/java/NoIndexSupport/.classpath
+++ b/its/projects/java/NoIndexSupport/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/its/projects/java/NoIndexSupport/.project
+++ b/its/projects/java/NoIndexSupport/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>NoIndexSupport</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/its/projects/java/NoIndexSupport/.settings/org.eclipse.core.resources.prefs
+++ b/its/projects/java/NoIndexSupport/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/its/projects/java/NoIndexSupport/.settings/org.eclipse.jdt.core.prefs
+++ b/its/projects/java/NoIndexSupport/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/its/projects/java/NoIndexSupport/.settings/org.sonarlint.eclipse.core.prefs
+++ b/its/projects/java/NoIndexSupport/.settings/org.sonarlint.eclipse.core.prefs
@@ -1,0 +1,4 @@
+autoEnabled=true
+bindingSuggestionsDisabled=false
+eclipse.preferences.version=1
+indexingBasedOnEclipsePlugIns=false

--- a/its/projects/java/NoIndexSupport/src/hello/Hello.java
+++ b/its/projects/java/NoIndexSupport/src/hello/Hello.java
@@ -1,0 +1,7 @@
+package hello;
+
+public class Hello {
+  public static void main(String... args) {
+    System.out.println("Hello");
+  }
+}

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
@@ -54,6 +54,12 @@ public class SonarLintDocumentation {
 
   public static final String GITHUB_RELEASES = "https://github.com/SonarSource/sonarlint-eclipse/releases";
 
+  // Links to Eclipse plug-ins that are used and have sub-plug-ins
+  public static final String ECLIPSE_JDT = "https://projects.eclipse.org/projects/eclipse.jdt";
+  public static final String ECLIPSE_CDT = "https://projects.eclipse.org/projects/tools.cdt";
+  public static final String ECLIPSE_M2E = "https://projects.eclipse.org/projects/technology.m2e";
+  public static final String ECLIPSE_BUILDSHIP = "https://projects.eclipse.org/projects/tools.buildship";
+
   private SonarLintDocumentation() {
     // utility class
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfiguration.java
@@ -35,6 +35,7 @@ public class SonarLintProjectConfiguration {
   private EclipseProjectBinding projectBinding;
   private boolean autoEnabled = true;
   private boolean bindingSuggestionsDisabled = false;
+  private boolean indexingBasedOnEclipsePlugIns = true;
 
   public List<ExclusionItem> getFileExclusions() {
     return fileExclusions;
@@ -109,4 +110,11 @@ public class SonarLintProjectConfiguration {
     this.bindingSuggestionsDisabled = bindingSuggestionsDisabled;
   }
 
+  public boolean isIndexingBasedOnEclipsePlugIns() {
+    return this.indexingBasedOnEclipsePlugIns;
+  }
+
+  public void setIndexingBasedOnEclipsePlugIns(boolean indexingBasedOnEclipsePlugIns) {
+    this.indexingBasedOnEclipsePlugIns = indexingBasedOnEclipsePlugIns;
+  }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfigurationManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfigurationManager.java
@@ -98,13 +98,13 @@ public class SonarLintProjectConfigurationManager {
     projectConfig.setAutoEnabled(projectNode.getBoolean(P_AUTO_ENABLED_KEY, true));
     projectConfig.setBindingSuggestionsDisabled(projectNode.getBoolean(P_BINDING_SUGGESTIONS_DISABLED_KEY, false));
 
-    // When importing a project (but not when restarting the workspace), the when accessing the project preferences for
-    // the first time, they cannot be loaded and will fallback to the default value (in this case here "true"). This
-    // seems to be coming from Eclipse itself as the preferences are loaded lazily. THis is no problem as when a
-    // project is imported right after importing all files will be shown as changed (added) and then the preference
-    // will be read again and then it is available!
-    // When importing a project, the preferences are not loaded lazily anymore but fetched from cache and are not
-    // falling back to the default values!
+    // When importing a project (but not when (re-)starting the workspace), and the project preferences are accessed
+    // for the first time, they cannot be loaded and will fallback to the default values (in this case here "true").
+    // This seems to be coming from Eclipse itself as the preferences are loaded lazily. This is no problem as when a
+    // project is imported, right after importing, all files will be shown as changed (added) and then the preferences
+    // will be read again (in FileSystemSynchronizer) and then they are fully available!
+    // When starting a workspace and the project was already imported earlier, the preferences are not loaded lazily
+    // anymore but fetched from cache and are not falling back to the default values - they are available at all times.
     projectConfig.setIndexingBasedOnEclipsePlugIns(projectNode.getBoolean(P_INDEXING_BASED_ON_ECLIPSE_PLUGINS, true));
 
     return projectConfig;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfigurationManager.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintProjectConfigurationManager.java
@@ -56,6 +56,7 @@ public class SonarLintProjectConfigurationManager {
   private static final String P_MODULE_KEY = "moduleKey";
   private static final String P_AUTO_ENABLED_KEY = "autoEnabled";
   public static final String P_BINDING_SUGGESTIONS_DISABLED_KEY = "bindingSuggestionsDisabled";
+  public static final String P_INDEXING_BASED_ON_ECLIPSE_PLUGINS = "indexingBasedOnEclipsePlugIns";
 
   private static final Set<String> BINDING_RELATED_PROPERTIES = Set.of(P_PROJECT_KEY, P_CONNECTION_ID, P_BINDING_SUGGESTIONS_DISABLED_KEY);
 
@@ -96,6 +97,16 @@ public class SonarLintProjectConfigurationManager {
     }
     projectConfig.setAutoEnabled(projectNode.getBoolean(P_AUTO_ENABLED_KEY, true));
     projectConfig.setBindingSuggestionsDisabled(projectNode.getBoolean(P_BINDING_SUGGESTIONS_DISABLED_KEY, false));
+
+    // When importing a project (but not when restarting the workspace), the when accessing the project preferences for
+    // the first time, they cannot be loaded and will fallback to the default value (in this case here "true"). This
+    // seems to be coming from Eclipse itself as the preferences are loaded lazily. THis is no problem as when a
+    // project is imported right after importing all files will be shown as changed (added) and then the preference
+    // will be read again and then it is available!
+    // When importing a project, the preferences are not loaded lazily anymore but fetched from cache and are not
+    // falling back to the default values!
+    projectConfig.setIndexingBasedOnEclipsePlugIns(projectNode.getBoolean(P_INDEXING_BASED_ON_ECLIPSE_PLUGINS, true));
+
     return projectConfig;
   }
 
@@ -133,6 +144,7 @@ public class SonarLintProjectConfigurationManager {
 
     projectNode.putBoolean(P_AUTO_ENABLED_KEY, configuration.isAutoEnabled());
     projectNode.putBoolean(P_BINDING_SUGGESTIONS_DISABLED_KEY, configuration.isBindingSuggestionsDisabled());
+    projectNode.putBoolean(P_INDEXING_BASED_ON_ECLIPSE_PLUGINS, configuration.isIndexingBasedOnEclipsePlugIns());
     try {
       projectNode.flush();
     } catch (BackingStoreException e) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
@@ -165,7 +165,7 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
       + "<a>Buildship</a> (Gradle) to exclude certain files (like compilation or build output\ndirectories) as well "
       + "as from the analysis with the effect of improving the overall performance and lowering the\nmemory "
       + "footprint.\nOpting out might negate these positive effects but can be benefitial in certain cases - this "
-      + "should be assessed individually!");
+      + "should be assessed individually.");
     indexExclusionsInformation.addSelectionListener(new SelectionAdapter() {
       @Override
       public void widgetSelected(SelectionEvent e) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintProjectPropertyPage.java
@@ -65,6 +65,9 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
   private Link newCodeInformation;
   private Link newCodeProjectStatus;
 
+  // Information displayed regarding index exclusions coming from sub-plug-ins (e.g. JDT/CDT/M2e/Buildship)
+  private Button indexExclusionEnabledBtn;
+
   public SonarLintProjectPropertyPage() {
     setTitle(Messages.SonarProjectPropertyPage_title);
   }
@@ -149,6 +152,49 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
       }
     });
 
+    // Indexing opt-out
+    var indexExclusionsHeader = new Label(container, SWT.NONE);
+    indexExclusionsHeader.setLayoutData(gd);
+    indexExclusionsHeader.setFont(font);
+    indexExclusionsHeader.setText("Project indexing based on other Eclipse plug-ins");
+
+    var indexExclusionsInformation = new Link(container, SWT.NONE);
+    indexExclusionsInformation.setLayoutData(new GridData(SWT.LEFT, SWT.DOWN, true, false, 2, 1));
+    indexExclusionsInformation.setText("SonarLint makes use of other Eclipse plug-ins when it comes to indexing a "
+      + "project. Dependending on the project we\nrely on Eclipse <a>JDT</a>, <a>CDT</a>, <a>M2E</a> (Maven), or "
+      + "<a>Buildship</a> (Gradle) to exclude certain files (like compilation or build output\ndirectories) as well "
+      + "as from the analysis with the effect of improving the overall performance and lowering the\nmemory "
+      + "footprint.\nOpting out might negate these positive effects but can be benefitial in certain cases - this "
+      + "should be assessed individually!");
+    indexExclusionsInformation.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        switch (e.text) {
+          case "JDT":
+            BrowserUtils.openExternalBrowser(SonarLintDocumentation.ECLIPSE_JDT, container.getDisplay());
+            break;
+          case "CDT":
+            BrowserUtils.openExternalBrowser(SonarLintDocumentation.ECLIPSE_CDT, container.getDisplay());
+            break;
+          case "M2E":
+            BrowserUtils.openExternalBrowser(SonarLintDocumentation.ECLIPSE_M2E, container.getDisplay());
+            break;
+          case "Buildship":
+            BrowserUtils.openExternalBrowser(SonarLintDocumentation.ECLIPSE_BUILDSHIP, container.getDisplay());
+            break;
+          default:
+            break;
+        }
+      }
+    });
+
+    // Binding information and settings
+    indexExclusionEnabledBtn = new Button(container, SWT.CHECK);
+    indexExclusionEnabledBtn.setText("Rely on Eclipse plug-ins for indexing and exclusions (changing requires a "
+      + "restart of the IDE)");
+    indexExclusionEnabledBtn.setSelection(getProjectConfig().isIndexingBasedOnEclipsePlugIns());
+    enabledBtn.setLayoutData(layoutData);
+
     updateConnectionState();
     updateNewCodeState();
     container.requestLayout();
@@ -224,6 +270,7 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
   @Override
   protected void performDefaults() {
     enabledBtn.setEnabled(true);
+    indexExclusionEnabledBtn.setEnabled(true);
     super.performDefaults();
   }
 
@@ -231,6 +278,7 @@ public class SonarLintProjectPropertyPage extends PropertyPage {
   public boolean performOk() {
     var projectConfig = getProjectConfig();
     projectConfig.setAutoEnabled(enabledBtn.getSelection());
+    projectConfig.setIndexingBasedOnEclipsePlugIns(indexExclusionEnabledBtn.getSelection());
     SonarLintCorePlugin.saveConfig(getProject(), projectConfig);
     return super.performOk();
   }


### PR DESCRIPTION
[SLE-967](https://sonarsource.atlassian.net/browse/SLE-967)

Users can opt-out per project from the indexing support (including exclusions) based on other Eclipse plug-ins like JDT/CDT/M2E/Buildship.

This should only be done in very specific cases; the information in the UI also provides this, and opting out should be assessed from project to project.

Cases are projects using Maven and also have source code in the "target" directory for example, and other corner cases (e.g. the performance is decreased because of the Gradle Tooling API version used transitively)!

## Documentation

I reached out to the squad to add a small paragraph to the [Troubleshooting](https://docs.sonarsource.com/sonarlint/eclipse/troubleshooting/) page explaining this and when it can be applied.

[SLE-967]: https://sonarsource.atlassian.net/browse/SLE-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ