### PR TITLE
SLE-979 Migrate deprecated cirrus-module v2 to v3

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -33,7 +33,7 @@ only_main_branches: &ONLY_MAIN_BRANCHES
   skip: "changesIncludeOnly('docs/*', '**/README.md')"
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*")
 
-eks_container: &CONTAINER_DEFINITION
+container_definition: &CONTAINER_DEFINITION
   image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3.9-latest
   region: eu-central-1
   cluster_name: ${CIRRUS_CLUSTER_NAME}
@@ -47,7 +47,6 @@ eks_builder_container: &BUILDER_CONTAINER_DEFINITION
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: m6a.large
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
 
 maven_cache: &SETUP_MAVEN_CACHE
   maven_cache:

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -15,7 +15,7 @@ only_dedicated_branches: &ONLY_IF
   skip: "changesIncludeOnly('.github/*', 'docs/*', 'org.sonarlint.eclipse.core.tests/*', 'scripts/*', '**/README.md')"
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == ""
 
-eks_container: &CONTAINER_DEFINITION
+container_definition: &CONTAINER_DEFINITION
   image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3.9-latest
   region: eu-central-1
   cluster_name: ${CIRRUS_CLUSTER_NAME}
@@ -29,7 +29,6 @@ eks_builder_container: &BUILDER_CONTAINER_DEFINITION
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: m6a.large
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
 
 # Maven cache based on pom.xml files and the Eclipse (Tycho) target platforms
 maven_cache_qa: &SETUP_MAVEN_CACHE

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 load("cirrus", "env", "fs", "yaml")
 
 


### PR DESCRIPTION
[SLE-979](https://sonarsource.atlassian.net/browse/SLE-979)

1. Update cirrus-module v2 to v3.
2. Do not call the deprecated AWS feature method parameters `builder_subnet_id`.
3. It is recommended to not use `ec2_instance` or `eks_container` root keys.

[SLE-979]: https://sonarsource.atlassian.net/browse/SLE-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ