### PR TITLE
SLE-1001 Use fixed development reference for SQ instead of version number

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -203,7 +203,7 @@ qa_connectedModeSonarQube_task:
         SQ_VERSION: 'LATEST_RELEASE'
         QA_CATEGORY: 'LATEST_RELEASE'
     - env:
-        SQ_VERSION: '10.8.0.99052'
+        SQ_VERSION: 'DEV[10.8]'
         QA_CATEGORY: 'DEV'
   <<: *SETUP_MAVEN_CACHE_QA
   <<: *SETUP_ORCHESTRATOR_CACHE


### PR DESCRIPTION
[SLE-1001](https://sonarsource.atlassian.net/browse/SLE-1001)

This is done by other repos as well for now until Orchestrator is fixed.

[SLE-1001]: https://sonarsource.atlassian.net/browse/SLE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ