### PR TITLE
SLE-928: Await Rule Description content correctly

### DIFF
--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/RuleDescriptionViewTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/RuleDescriptionViewTest.java
@@ -59,8 +59,8 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
     ruleDescriptionView.open();
 
     new WaitUntil(new RuleDescriptionViewIsLoaded(ruleDescriptionView));
-    var flatTextContent = ruleDescriptionView.getFlatTextContent();
-    await().untilAsserted(() -> assertThat(flatTextContent).contains("java:S106"));
+    await().untilAsserted(() -> assertThat(ruleDescriptionView.getFlatTextContent())
+      .contains("java:S106"));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
     ruleDescriptionView.open();
 
     new WaitUntil(new RuleDescriptionViewIsLoaded(ruleDescriptionView));
-    var flatTextContent = ruleDescriptionView.getFlatTextContent();
-    await().untilAsserted(() -> assertThat(flatTextContent).contains("python:PrintStatementUsage"));
+    await().untilAsserted(() -> assertThat(ruleDescriptionView.getFlatTextContent())
+      .contains("python:PrintStatementUsage"));
   }
 }


### PR DESCRIPTION
[SLE-928](https://sonarsource.atlassian.net/browse/SLE-928)

Instead of testing the same value every time, for every iteration, we check the new value and then check it.

[SLE-928]: https://sonarsource.atlassian.net/browse/SLE-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ