### PR TITLE
SLE-988: Update links to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SonarQube for IDE: Eclipse helps you deliver [Clean Code](https://www.sonarsourc
 Installing and using
 --------------------
 
-See https://docs.sonarsource.com/sonarlint/eclipse/getting-started/installation/ and https://marketplace.eclipse.org/content/sonarlint
+See https://docs.sonarsource.com/sonarqube-for-ide/eclipse/getting-started/installation/ and https://marketplace.eclipse.org/content/sonarlint
 
 For offline installation and older versions see the update site archive at https://binaries.sonarsource.com/?prefix=SonarLint-for-Eclipse/releases/
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/documentation/SonarLintDocumentation.java
@@ -21,7 +21,7 @@ package org.sonarlint.eclipse.core.documentation;
 
 public class SonarLintDocumentation {
 
-  private static final String BASE_DOCS_URL = "https://docs.sonarsource.com/sonarlint/eclipse";
+  private static final String BASE_DOCS_URL = "https://docs.sonarsource.com/sonarqube-for-ide/eclipse";
   public static final String CLEAN_AS_YOU_CODE = BASE_DOCS_URL + "/clean-as-you-code-in-the-ide";
   public static final String CONNECTED_MODE_LINK = BASE_DOCS_URL + "/team-features/connected-mode/";
   public static final String CONNECTED_MODE_BENEFITS = CONNECTED_MODE_LINK + "#benefits";

--- a/org.sonarlint.eclipse.feature/feature.properties
+++ b/org.sonarlint.eclipse.feature/feature.properties
@@ -10,4 +10,4 @@ Copyright 2015-2024 SonarSource S.A, Switzerland.
 license=\
 Licensed under the GNU Lesser General Public License, Version 3.0\n\
 \n\
-Visit https://docs.sonarsource.com/sonarlint/eclipse/license/
+Visit https://docs.sonarsource.com/sonarqube-for-ide/eclipse/license/

--- a/org.sonarlint.eclipse.feature/feature.xml
+++ b/org.sonarlint.eclipse.feature/feature.xml
@@ -6,11 +6,11 @@
       provider-name="%provider_name"
       plugin="org.sonarlint.eclipse.ui">
 
-   <description url="https://docs.sonarsource.com/sonarlint/eclipse/">
+   <description url="https://docs.sonarsource.com/sonarqube-for-ide/eclipse/">
       %description
    </description>
 
-   <copyright url="https://docs.sonarsource.com/sonarlint/eclipse/license/">
+   <copyright url="https://docs.sonarsource.com/sonarqube-for-ide/eclipse/license/">
       %copyright
    </copyright>
 

--- a/org.sonarlint.eclipse.site/category.xml
+++ b/org.sonarlint.eclipse.site/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <description url="https://docs.sonarsource.com/sonarlint/eclipse/">
+   <description url="https://docs.sonarsource.com/sonarqube-for-ide/eclipse/">
       SonarLint for Eclipse
    </description>
    <feature id="org.sonarlint.eclipse.feature" version="0.0.0">

--- a/org.sonarlint.eclipse.ui/about.properties
+++ b/org.sonarlint.eclipse.ui/about.properties
@@ -5,4 +5,4 @@ featureText=SonarLint for Eclipse\n\
  Copyright 2015-2024 SonarSource S.A, Switzerland.\n\
  Licensed under the GNU Lesser General Public License, Version 3.0\n\
  \n\
- Visit https://docs.sonarsource.com/sonarlint/eclipse/license/\n\
+ Visit https://docs.sonarsource.com/sonarqube-for-ide/eclipse/license/\n\

--- a/org.sonarlint.eclipse.ui/intro/tutorialsExtensionContent.xml
+++ b/org.sonarlint.eclipse.ui/intro/tutorialsExtensionContent.xml
@@ -9,7 +9,7 @@
       <!-- 1) Investigating issues, getting started with SonarLint -->
       <link style-id="content-link"
             label="Investigating issues"
-            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarlint/eclipse/using-sonarlint/investigating-issues/"
+            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarqube-for-ide/eclipse/using-sonarlint/investigating-issues/"
             id="investigatingIssues">
         <text>Learn how to investigate issues found by SonarQube for Eclipse</text>
       </link>
@@ -17,7 +17,7 @@
       <!-- 2) Learn about Connected Mode, setting it up -->
       <link style-id="content-link"
             label="Connected Mode"
-            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarlint/eclipse/team-features/connected-mode/"
+            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarqube-for-ide/eclipse/team-features/connected-mode/"
             id="connectedMode">
         <text>Learn how to leverage Connected Mode to bring even more benefits to your experience</text>
       </link>
@@ -25,7 +25,7 @@
       <!-- 3) Troubleshooting and how to gather necessary information for the Sonar Community Forum -->
       <link style-id="content-link"
             label="Troubleshooting"
-            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarlint/eclipse/troubleshooting/"
+            url="http://org.eclipse.ui.intro/openBrowser?url=https://docs.sonarsource.com/sonarqube-for-ide/eclipse/troubleshooting/"
             id="troubleshooting">
         <text>Learn how to troubleshoot issues related to SonarQube for Eclipse</text>
       </link>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <name>SonarLint for Eclipse</name>
   <description></description>
-  <url>https://docs.sonarsource.com/sonarlint/eclipse</url>
+  <url>https://docs.sonarsource.com/sonarqube-for-ide/eclipse</url>
   <inceptionYear>2015</inceptionYear>
   <organization>
     <name>SonarSource</name>


### PR DESCRIPTION
[SLE-988](https://sonarsource.atlassian.net/browse/SLE-988)

The user facing links to the SonarQube for IDE: Eclipse documentation are updated.

[SLE-988]: https://sonarsource.atlassian.net/browse/SLE-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ