### PR TITLE
SLE-1003: Reassess CPU / memory for tasks

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -81,7 +81,7 @@ consistency_task:
   <<: *ONLY_IF
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
-    cpu: 1
+    cpu: 2
     memory: 2G
   check_script: |
     SLCORE_VERSION="$(maven_expression "sloop.version")"
@@ -152,7 +152,7 @@ validate_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 4G
+    memory: 6G
     type: m6a.large
   env:
     DEPLOY_PULL_REQUEST: false
@@ -195,7 +195,7 @@ qa_connectedModeSonarQube_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 12G
+    memory: 16G
     type: m6a.large
   env:
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
@@ -278,7 +278,7 @@ qa_connectedModeSonarCloud_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 10G
+    memory: 12G
     type: m6a.large
   env:
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
@@ -351,7 +351,7 @@ qa_standaloneMode_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 10G
+    memory: 12G
     type: m6a.large
   env:
     ARTIFACTORY_API_KEY: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
@@ -495,7 +495,7 @@ mend_scan_task:
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
     cpu: 4
-    memory: 8G
+    memory: 4G
     type: m6a.large
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]

--- a/.cirrus.ibuilds.yml
+++ b/.cirrus.ibuilds.yml
@@ -45,7 +45,7 @@ qa_ibuilds_task:
   skip_notifications: true
   eks_container:
     <<: *BUILDER_CONTAINER_DEFINITION
-    cpu: 6
+    cpu: 4
     memory: 12G
     type: m6a.large
   env:


### PR DESCRIPTION
[SLE-1003](https://sonarsource.atlassian.net/browse/SLE-1003)

Some tasks were hitting their CPU limit and needed more power, some tasks were running OOM sometimes because they needed more memory.

For some tasks having too many CPUs or too much memory assigned this was finetuned as well.

[SLE-1003]: https://sonarsource.atlassian.net/browse/SLE-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ