### PR TITLE
SLE-1030 Bump core version to 10.12.1 (drop Bearer auth with SQ 10.0 to 10.3)

### DIFF
--- a/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
@@ -41,6 +41,6 @@ Require-Bundle: org.eclipse.equinox.security,
  org.eclipse.team.core,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.text,
- org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.12.0,10.13.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.12.1,10.13.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.text,
  org.eclipse.compare,
  org.eclipse.core.expressions,
- org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.12.0,10.13.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[10.12.1,10.13.0)"
 Export-Package: org.sonarlint.eclipse.ui.internal;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.backend;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.notifications;x-friends:="org.sonarlint.eclipse.core.tests",

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <tycho.version>4.0.8</tycho.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>10.12.0.79820</sloop.version>
+    <sloop.version>10.12.1.79852</sloop.version>
     
     <!-- SonarQube analysis -->
     <sonar.java.source>11</sonar.java.source>

--- a/target-platforms/commons-build.target
+++ b/target-platforms/commons-build.target
@@ -12,7 +12,7 @@
         <dependency>
           <groupId>org.sonarsource.sonarlint.core</groupId>
           <artifactId>sonarlint-java-client-osgi</artifactId>
-          <version>10.12.0.79820</version>
+          <version>10.12.1.79852</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
[SLE-1030](https://sonarsource.atlassian.net/browse/SLE-1030)



[SLE-1030]: https://sonarsource.atlassian.net/browse/SLE-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ