### PR TITLE
SLE-1032: Remove `sonar.password` from SQ-S ITs

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/AbstractSonarQubeConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/AbstractSonarQubeConnectedModeTest.java
@@ -123,9 +123,13 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
     Map<String, String> analysisProperties) {
     var build = MavenBuild.create(new File(folder, path))
       .setCleanPackageSonarGoals()
-      .setProperty("sonar.login", Server.ADMIN_LOGIN)
-      .setProperty("sonar.password", Server.ADMIN_PASSWORD)
       .setProperty("sonar.projectKey", projectKey);
+    if (orchestrator.getServer().version().isGreaterThanOrEquals(10, 2)) {
+      build = build.setProperty("sonar.token", orchestrator.getDefaultAdminToken());
+    } else {
+      build = build.setProperty("sonar.login", Server.ADMIN_LOGIN)
+        .setProperty("sonar.password", Server.ADMIN_PASSWORD);
+    }
 
     for (var pair : analysisProperties.entrySet()) {
       build = build.setProperty(pair.getKey(), pair.getValue());
@@ -136,11 +140,6 @@ public abstract class AbstractSonarQubeConnectedModeTest extends AbstractSonarLi
 
   /** Bind a specific project to SonarQube */
   protected static void createConnectionAndBindProject(OrchestratorRule orchestrator, String projectKey) {
-    createConnectionAndBindProject(orchestrator, projectKey, Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD);
-  }
-
-  protected static void createConnectionAndBindProject(OrchestratorRule orchestrator, String projectKey,
-    String username, String password) {
     var wizard = new ServerConnectionWizard();
     wizard.open();
     new ServerConnectionWizard.ServerTypePage(wizard).selectSonarQube();

--- a/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/SonarQubeConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sq/src/org/sonarlint/eclipse/its/connected/sq/SonarQubeConnectedModeTest.java
@@ -21,7 +21,6 @@ package org.sonarlint.eclipse.its.connected.sq;
 
 import com.google.gson.Gson;
 import com.sonar.orchestrator.container.Edition;
-import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.http.HttpMethod;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
 import java.io.InputStreamReader;
@@ -469,8 +468,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
       .setPermission("issueadmin"));
 
     // 6) Remove connections and reconnect with user
-    createConnectionAndBindProject(orchestrator, MAVEN2_PROJECT_KEY, INSUFFICIENT_PERMISSION_USER,
-      INSUFFICIENT_PERMISSION_USER);
+    createConnectionAndBindProject(orchestrator, MAVEN2_PROJECT_KEY);
 
     // 7) Remove binding suggestion notification
     new DefaultLink(shellByName("SonarQube - Binding Suggestion").get(), "Don't ask again").click();
@@ -559,7 +557,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
     setFocusOnNewCode(false);
 
     // 3) bind to project on SonarQube / check issues and taint vulnerabilities exist
-    createConnectionAndBindProject(orchestrator, MAVEN_TAINT_PROJECT_KEY, Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD);
+    createConnectionAndBindProject(orchestrator, MAVEN_TAINT_PROJECT_KEY);
 
     new DefaultLink(shellByName("SonarLint - Binding Suggestion").get(), "Don't ask again").click();
 
@@ -586,7 +584,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
       Map.of("sonar.projectVersion", "1.2-SNAPSHOT"));
 
     // 5) bind to project on SonarQube / check that new code period preference is working
-    createConnectionAndBindProject(orchestrator, MAVEN_TAINT_PROJECT_KEY, Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD);
+    createConnectionAndBindProject(orchestrator, MAVEN_TAINT_PROJECT_KEY);
 
     waitForAnalysisReady(MAVEN_TAINT_PROJECT_KEY);
 
@@ -628,7 +626,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
     new DefaultEditor().close();
 
     // 3) bind to project on SonarQube / check issues exist now
-    createConnectionAndBindProject(orchestrator, DBD_PROJECT_KEY, Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD);
+    createConnectionAndBindProject(orchestrator, DBD_PROJECT_KEY);
     shellByName("SonarQube - Binding Suggestion").ifPresent(shell -> new DefaultLink(shell, "Don't ask again").click());
 
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("dbd.py"));
@@ -674,7 +672,7 @@ public class SonarQubeConnectedModeTest extends AbstractSonarQubeConnectedModeTe
     new DefaultEditor().close();
 
     // 3) bind to project on SonarQube / check issues exist now
-    createConnectionAndBindProject(orchestrator, CUSTOM_SECRETS_PROJECT_KEY, Server.ADMIN_LOGIN, Server.ADMIN_PASSWORD);
+    createConnectionAndBindProject(orchestrator, CUSTOM_SECRETS_PROJECT_KEY);
     shellByName("SonarQube - Binding Suggestion").ifPresent(shell -> new DefaultLink(shell, "Don't ask again").click());
 
     openFileAndWaitForAnalysisCompletion(rootProject.getResource("Heresy.txt"));


### PR DESCRIPTION
[SLE-1032](https://sonarsource.atlassian.net/browse/SLE-1032)

Username/password authentication was removed from the UI and the authentication is now also unavailable for SQ-S 2025 LTA. The ITs have been adjusted.

[SLE-1032]: https://sonarsource.atlassian.net/browse/SLE-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ