### PR TITLE
SLE-1041: Change oldest target definition

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -362,7 +362,7 @@ qa_standaloneMode_task:
     MAVEN_OPTS: -Xmx3072m
   matrix:
     - env:
-        TARGET_PLATFORM: 'oldest-java-11_e48'
+        TARGET_PLATFORM: 'oldest-java-11_e417'
     - env:
         TARGET_PLATFORM: 'latest-java-17_e431'
     - env:
@@ -441,7 +441,7 @@ qa_cdtIntegration_task:
     MAVEN_OPTS: -Xmx3072m
   matrix:
     - env:
-        TARGET_PLATFORM: 'oldest-java-11_e48'
+        TARGET_PLATFORM: 'oldest-java-11_e417'
     - env:
         TARGET_PLATFORM: 'latest-java-17_e431'
     - env:

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/RuleDescriptionViewTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/RuleDescriptionViewTest.java
@@ -40,8 +40,8 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
 
   @Test
   public void openRuleDescription() {
-    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.8 requires GTK3 tho!
-    Assume.assumeTrue(!"oldest-java-11_e48".equals(System.getProperty("target.platform")));
+    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.`7 requires GTK3 tho!
+    Assume.assumeTrue(!"oldest-java-11_e417".equals(System.getProperty("target.platform")));
 
     new JavaPerspective().open();
     var ruleDescriptionView = new RuleDescriptionView();
@@ -65,8 +65,8 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
 
   @Test
   public void openRuleDescription_with_educational_content() {
-    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.8 requires GTK3 tho!
-    Assume.assumeTrue(!"oldest-java-11_e48".equals(System.getProperty("target.platform")));
+    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.17 requires GTK3 tho!
+    Assume.assumeTrue(!"oldest-java-11_e417".equals(System.getProperty("target.platform")));
 
     var ruleConfigurationPreferences = RuleConfigurationPreferences.open();
     var monsterClassRule = ruleConfigurationPreferences.selectRule("java:S6539", "Java", "Classes should not depend on an excessive number of classes (aka Monster Class)");
@@ -104,8 +104,8 @@ public class RuleDescriptionViewTest extends AbstractSonarLintTest {
    */
   @Test
   public void openRuleRescription_with_PythonSyntaxHighlighting() {
-    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.8 requires GTK3 tho!
-    Assume.assumeTrue(!"oldest-java-11_e48".equals(System.getProperty("target.platform")));
+    // Because the CI can only provide GTK 4+ WebKit libraries, Eclipse 4.17 requires GTK3 tho!
+    Assume.assumeTrue(!"oldest-java-11_e417".equals(System.getProperty("target.platform")));
 
     new JavaPerspective().open();
     var ruleDescriptionView = new RuleDescriptionView();

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
@@ -86,7 +86,7 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
 
   @After
   public void enableAutomaticWorkspaceBuild() {
-    if ("oldest-java-11_e48".equals(System.getProperty("target.platform"))) {
+    if ("oldest-java-11_e417".equals(System.getProperty("target.platform"))) {
       var preferences = GeneralWorkspaceBuildPreferences.open();
       preferences.enableAutomaticBuild();
       preferences.ok();
@@ -101,7 +101,7 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
   @Test
   public void analyze_automatic_workspace_build_disabled() {
     // INFO: We only want to run it on one axis and the "oldest" ITs take the shortest!
-    Assume.assumeTrue("oldest-java-11_e48".equals(System.getProperty("target.platform")));
+    Assume.assumeTrue("oldest-java-11_e417".equals(System.getProperty("target.platform")));
 
     System.clearProperty("sonarlint.internal.ignoreNoAutomaticBuildWarning");
 
@@ -509,7 +509,7 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
   public void shouldAnalyseVirtualProject() throws Exception {
     // INFO: It is flaky when running on top of the oldest Eclipse version but works fine in the other test cases,
     // therefore it should be skipped in that particular situation!
-    Assume.assumeTrue(!"oldest-java-11_e48".equals(System.getProperty("target.platform")));
+    Assume.assumeTrue(!"oldest-java-11_e417".equals(System.getProperty("target.platform")));
 
     var remoteProjectDir = tempFolder.newFolder();
     FileUtils.copyDirectory(new File(projectDirectory, "java/java-simple"), remoteProjectDir);

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -277,7 +277,7 @@
       <activation>
         <property>
           <name>target.platform</name>
-          <value>oldest-java-11_e48</value>
+          <value>oldest-java-11_e417</value>
         </property>
       </activation>
       <build>

--- a/target-platforms/oldest-java-11_e417.target
+++ b/target-platforms/oldest-java-11_e417.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="sonarlint-oldest-java-11_e48" sequenceNumber="3">
+<target name="sonarlint-oldest-java-11_e417" sequenceNumber="1">
   <locations>
     <location type="Target" uri="file:${project_loc:/org.sonarlint.eclipse.its}/../target-platforms/commons-its.target" />
     
@@ -15,7 +15,7 @@
       <unit id="org.eclipse.php.feature.group" version="0.0.0" />
       <!-- Needed to build the test environment -->
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
-      <repository location="https://download.eclipse.org/releases/photon/" />
+      <repository location="https://download.eclipse.org/releases/2020-09/" />
     </location>
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -37,7 +37,7 @@
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.buildship.feature.group" version="0.0.0" />
-      <repository location="https://download.eclipse.org/buildship/updates/e48/releases/3.x" />
+      <repository location="https://download.eclipse.org/buildship/updates/e417/releases/3.x" />
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11" />


### PR DESCRIPTION
[SLE-1041](https://sonarsource.atlassian.net/browse/SLE-1041)

Move from 4.8 (Photon) to 4.17 (2020-09) as the minimal targeted version for ITs.

When the next version will be released, the actual "guard" will be put in place on the Eclipse Marketplace. Otherwise there is no strict guard build in place as the Eclipse Core / Runtime / UI plug-ins are not strictly bound to a Eclipse IDE version released.

[SLE-1041]: https://sonarsource.atlassian.net/browse/SLE-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ