### PR TITLE
SLE-1044: Update/released pop-up with SonarQube for Eclipse

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/ReleaseNotesPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/ReleaseNotesPopup.java
@@ -31,9 +31,9 @@ import org.sonarlint.eclipse.ui.internal.util.PopupUtils;
 public class ReleaseNotesPopup extends AbstractSonarLintVersionPopup {
   public ReleaseNotesPopup() {
     super("SonarQube for Eclipse - Release Notes",
-      "Thank you for installing / updating SonarLint. We invite you to learn about the recent changes by taking a"
-        + " look at the Release Notes. If you want to read them later, they can be found nested into the SonarLint "
-        + "preferences.");
+      "Thank you for installing / updating SonarQube for Eclipse (formerly known as SonarLint). We invite you to "
+        + "learn about the recent changes by taking a look at the Release Notes. If you want to read them later, they "
+        + "can be found nested into the SonarQube preferences.");
   }
 
   @Override


### PR DESCRIPTION
[SLE-1044](https://sonarsource.atlassian.net/browse/SLE-1044)

This pop-up still contained "SonarLint" and needed an update. For users coming from very old versions, we still contain the info that this plug-in used to be called "SonarLint".

[SLE-1044]: https://sonarsource.atlassian.net/browse/SLE-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ