### PR TITLE
SLE-1050: Remove binding properties listener appropriately

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/ConfigScopeSynchronizer.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/ConfigScopeSynchronizer.java
@@ -68,6 +68,7 @@ public class ConfigScopeSynchronizer implements IResourceChangeListener {
           + "' (pre close)");
       if (project != null) {
         SonarLintLogger.get().debug("Project about to be closed: " + project.getName());
+        SonarLintProjectConfigurationManager.removePreferenceChangeListenerForBindingProperties(project);
         backend.getConfigurationService()
           .didRemoveConfigurationScope(new DidRemoveConfigurationScopeParams(getConfigScopeId(project)));
       }
@@ -77,6 +78,7 @@ public class ConfigScopeSynchronizer implements IResourceChangeListener {
           + "' (pre delete)");
       if (project != null) {
         SonarLintLogger.get().debug("Project about to be deleted: " + project.getName());
+        SonarLintProjectConfigurationManager.removePreferenceChangeListenerForBindingProperties(project);
         backend.getConfigurationService()
           .didRemoveConfigurationScope(new DidRemoveConfigurationScopeParams(getConfigScopeId(project)));
       }


### PR DESCRIPTION
[SLE-1050](https://sonarsource.atlassian.net/browse/SLE-1050)

This was causing errors from SLCORE as the preferences were receiving events after the project was removed.

[SLE-1050]: https://sonarsource.atlassian.net/browse/SLE-1050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ