### PR TITLE
SLE-1065: Overhaul error notification

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
@@ -36,7 +36,6 @@ import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.eclipse.reddeer.swt.impl.link.DefaultLink;
-import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.junit.AfterClass;
@@ -118,10 +117,6 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
 
     // Because we only use CDT in here, we switch back for other tests to not get confused!
     new JavaPerspective().open();
-
-    // Because we might kill the connection in the middle of synchronization a 401 can happen, in
-    // this case an error will throw (correctly)
-    shellByName("SonarQube for Eclipse - An error occurred").ifPresent(DefaultShell::close);
   }
 
   @Before

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
@@ -118,6 +118,7 @@ public abstract class AbstractSonarLintTest {
     System.setProperty("sonarlint.internal.ignoreMissingFeature", "true");
     System.setProperty("sonarlint.internal.ignoreNoAutomaticBuildWarning", "true");
     System.setProperty("sonarlint.internal.hideVersionHint", "true");
+    System.setProperty("sonarlint.internal.noErrorNotification", "true");
   }
 
   @AfterClass
@@ -126,6 +127,7 @@ public abstract class AbstractSonarLintTest {
     System.clearProperty("sonarlint.internal.ignoreMissingFeature");
     System.clearProperty("sonarlint.internal.ignoreNoAutomaticBuildWarning");
     System.clearProperty("sonarlint.internal.hideVersionHint");
+    System.clearProperty("sonarlint.internal.noErrorNotification");
 
     // remove warning about soon unsupported version (there can be multiple)
     if ("oldest".equals(System.getProperty("target.platform"))) {

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/jobs/AnalyzeStandaloneProjectJobTest.java
@@ -20,6 +20,8 @@
 package org.sonarlint.eclipse.core.internal.jobs;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -107,12 +109,33 @@ public class AnalyzeStandaloneProjectJobTest extends SonarTestCase {
       }
 
       @Override
+      public void error(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        var stack = new StringWriter();
+        t.printStackTrace(new PrintWriter(stack));
+        error(msg, fromAnalyzer);
+        error(stack.toString(), fromAnalyzer);
+      }
+
+      @Override
       public void debug(String msg, boolean fromAnalyzer) {
         System.out.println("DEBUG " + msg);
       }
 
       @Override
+      public void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        var stack = new StringWriter();
+        t.printStackTrace(new PrintWriter(stack));
+        debug(msg, fromAnalyzer);
+        debug(stack.toString(), fromAnalyzer);
+      }
+
+      @Override
       public void traceIdeMessage(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
+
+      @Override
+      public void traceIdeMessage(@Nullable String msg, Throwable t) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     };

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/SonarLintProjectConfigurationManagerTest.java
@@ -20,6 +20,8 @@
 package org.sonarlint.eclipse.core.internal.resources;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.core.resources.ProjectScope;
@@ -53,11 +55,30 @@ public class SonarLintProjectConfigurationManagerTest extends SonarTestCase {
       }
 
       @Override
+      public void error(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        var stack = new StringWriter();
+        t.printStackTrace(new PrintWriter(stack));
+        error(msg, fromAnalyzer);
+        error(stack.toString(), fromAnalyzer);
+      }
+
+      @Override
       public void debug(String msg, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
+      }
+
+      @Override
+      public void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
       }
 
       @Override
       public void traceIdeMessage(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
+
+      @Override
+      public void traceIdeMessage(@Nullable String msg, Throwable t) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/tracking/SonarLintMarkerUpdaterTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonarlint.eclipse.core.internal.tracking;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +74,7 @@ public class SonarLintMarkerUpdaterTest extends SonarTestCase {
     SonarLintLogger.get().addLogListener(new LogListener() {
       @Override
       public void info(String msg, boolean fromAnalyzer) {
+        // We ignore info messages in UTs
       }
 
       @Override
@@ -84,11 +87,30 @@ public class SonarLintMarkerUpdaterTest extends SonarTestCase {
       }
 
       @Override
+      public void error(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        var stack = new StringWriter();
+        t.printStackTrace(new PrintWriter(stack));
+        error(msg, fromAnalyzer);
+        error(stack.toString(), fromAnalyzer);
+      }
+
+      @Override
       public void debug(String msg, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
+      }
+
+      @Override
+      public void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
       }
 
       @Override
       public void traceIdeMessage(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
+
+      @Override
+      public void traceIdeMessage(@Nullable String msg, Throwable t) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/utils/DurationUtilsTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonarlint.eclipse.core.internal.utils;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +50,7 @@ public class DurationUtilsTest {
     SonarLintLogger.get().addLogListener(new LogListener() {
       @Override
       public void info(@Nullable String msg, boolean fromAnalyzer) {
+        // We ignore info messages in UTs
       }
 
       @Override
@@ -56,11 +59,30 @@ public class DurationUtilsTest {
       }
 
       @Override
+      public void error(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        var stack = new StringWriter();
+        t.printStackTrace(new PrintWriter(stack));
+        error(msg, fromAnalyzer);
+        error(stack.toString(), fromAnalyzer);
+      }
+
+      @Override
       public void debug(@Nullable String msg, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
+      }
+
+      @Override
+      public void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+        // We ignore debug messages in UTs
       }
 
       @Override
       public void traceIdeMessage(@Nullable String msg) {
+        // INFO: We ignore Eclipse-specific tracing in UTs
+      }
+
+      @Override
+      public void traceIdeMessage(@Nullable String msg, Throwable t) {
         // INFO: We ignore Eclipse-specific tracing in UTs
       }
     });

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/SonarLintLogger.java
@@ -19,8 +19,6 @@
  */
 package org.sonarlint.eclipse.core;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.jdt.annotation.Nullable;
@@ -60,10 +58,7 @@ public class SonarLintLogger {
 
   public void error(String msg, Throwable t) {
     for (var listener : logListeners) {
-      listener.error(msg, false);
-      var stack = new StringWriter();
-      t.printStackTrace(new PrintWriter(stack));
-      listener.error(stack.toString(), false);
+      listener.error(msg, t, false);
     }
   }
 
@@ -93,10 +88,7 @@ public class SonarLintLogger {
 
   public void debug(String msg, Throwable t) {
     for (var listener : logListeners) {
-      listener.debug(msg, false);
-      var stack = new StringWriter();
-      t.printStackTrace(new PrintWriter(stack));
-      listener.debug(stack.toString(), false);
+      listener.debug(msg, t, false);
     }
   }
 
@@ -108,10 +100,7 @@ public class SonarLintLogger {
 
   public void traceIdeMessage(String msg, Throwable t) {
     for (var listener : logListeners) {
-      listener.traceIdeMessage(msg);
-      var stack = new StringWriter();
-      t.printStackTrace(new PrintWriter(stack));
-      listener.traceIdeMessage(stack.toString());
+      listener.traceIdeMessage(msg, t);
     }
   }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/LogListener.java
@@ -27,7 +27,11 @@ public interface LogListener {
 
   void error(@Nullable String msg, boolean fromAnalyzer);
 
+  void error(@Nullable String msg, Throwable t, boolean fromAnalyzer);
+
   void debug(@Nullable String msg, boolean fromAnalyzer);
+
+  void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer);
 
   /**
    *  This should only be used for IDE-specific logging and is not intended for tracing messages from SLCORE as these
@@ -35,4 +39,6 @@ public interface LogListener {
    *  extension point, ...
    */
   void traceIdeMessage(@Nullable String msg);
+
+  void traceIdeMessage(@Nullable String msg, Throwable t);
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -92,6 +92,7 @@ public class SonarLintGlobalConfiguration {
   private static final String PREF_SOON_UNSUPPORTED_CONNECTIONS = "soonUnsupportedSonarQubeConnections"; //$NON-NLS-1$
   private static final String PREF_NO_AUTOMATIC_BUILD_WARNING = "noAutomaticBuildWarning"; //$NON-NLS-1$
   private static final String PREF_NO_CONNECTION_SUGGESTIONS = "NoConnectionSuggestions"; //$NON-NLS-1$
+  private static final String PREF_NO_ERROR_NOTIFICATION = "noErrorNotification"; //$NON-NLS-1$
 
   // When SonarLint is updated (or installed), we inform the user by opening the "Welcome" page and show a notification
   // about the new Release Notes. When a new version is available, we will inform the user as well (but only once a
@@ -448,6 +449,18 @@ public class SonarLintGlobalConfiguration {
 
   public static void setNoAutomaticBuildWarning() {
     setPreferenceBoolean(getWorkspaceLevelPreferenceNode(), PREF_NO_AUTOMATIC_BUILD_WARNING, true);
+  }
+
+  public static boolean noErrorNotifcation() {
+    // For integration tests we need to disable the notifications
+    var property = System.getProperty("sonarlint.internal.noErrorNotification");
+    return property == null || property.isBlank()
+      ? getPreferenceBoolean(PREF_NO_ERROR_NOTIFICATION)
+      : Boolean.parseBoolean(property);
+  }
+
+  public static void setNoErrorNotification() {
+    setPreferenceBoolean(getWorkspaceLevelPreferenceNode(), PREF_NO_ERROR_NOTIFICATION, true);
   }
 
   public static boolean noConnectionSuggestions() {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintUiPlugin.java
@@ -113,6 +113,13 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
     }
 
     @Override
+    public void error(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+      if (PlatformUI.isWorkbenchRunning()) {
+        doAsyncInUiThread(() -> getSonarConsole().error(msg, t, fromAnalyzer));
+      }
+    }
+
+    @Override
     public void debug(@Nullable String msg, boolean fromAnalyzer) {
       if (PlatformUI.isWorkbenchRunning()) {
         doAsyncInUiThread(() -> getSonarConsole().debug(msg, fromAnalyzer));
@@ -120,9 +127,23 @@ public class SonarLintUiPlugin extends AbstractUIPlugin {
     }
 
     @Override
+    public void debug(@Nullable String msg, Throwable t, boolean fromAnalyzer) {
+      if (PlatformUI.isWorkbenchRunning()) {
+        doAsyncInUiThread(() -> getSonarConsole().debug(msg, t, fromAnalyzer));
+      }
+    }
+
+    @Override
     public void traceIdeMessage(@Nullable String msg) {
       if (PlatformUI.isWorkbenchRunning()) {
         doAsyncInUiThread(() -> getSonarConsole().traceIdeMessage(msg));
+      }
+    }
+
+    @Override
+    public void traceIdeMessage(@Nullable String msg, Throwable t) {
+      if (PlatformUI.isWorkbenchRunning()) {
+        doAsyncInUiThread(() -> getSonarConsole().traceIdeMessage(msg, t));
       }
     }
 


### PR DESCRIPTION
[SLE-1065](https://sonarsource.atlassian.net/browse/SLE-1065)

When a user decide to ignore an error, also ignore "similar" errors. Also give the user the opportunity to not show any error notifications again.

Therefore the logging logic was overhauled (which I would have to do anyway for a proper error reporting mechanism that is planned to be implemented later).

[SLE-1065]: https://sonarsource.atlassian.net/browse/SLE-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ