### PR TITLE
SLE-1068: Add SonarQube views to other perspectives

### DIFF
--- a/org.sonarlint.eclipse.ui/plugin.xml
+++ b/org.sonarlint.eclipse.ui/plugin.xml
@@ -1707,6 +1707,7 @@
   </extension>
 
   <extension point="org.eclipse.ui.perspectiveExtensions">
+  	<!-- JDT provided main Java development perspective -->
     <perspectiveExtension
         targetID="org.eclipse.jdt.ui.JavaPerspective">
         <view id="org.sonarlint.eclipse.ui.views.IssueLocationsView"
@@ -1715,6 +1716,49 @@
         <view id="org.sonarlint.eclipse.ui.views.issues.IssuesView"
             relative="org.eclipse.ui.views.ProblemView"
             relationship="stack"/>
+        <view id="org.sonarlint.eclipse.ui.ServersView"
+            relative="org.eclipse.ui.views.ProblemView"
+            relationship="right"/>
+        <view id="org.sonarlint.eclipse.ui.views.RuleDescriptionWebView"
+            relative="org.eclipse.ui.views.ContentOutline"
+            relationship="stack" visible="false"/>
+        <viewShortcut
+              id="org.sonarlint.eclipse.ui.views.issues.IssuesView">
+        </viewShortcut>
+    </perspectiveExtension>
+    
+    <!-- CDT provided main C/C++ development perspective -->
+    <perspectiveExtension
+        targetID="org.eclipse.cdt.ui.CPerspective">
+        <view id="org.sonarlint.eclipse.ui.views.IssueLocationsView"
+            relative="org.eclipse.ui.views.ContentOutline"
+            relationship="stack" visible="false"/>
+        <view id="org.sonarlint.eclipse.ui.views.issues.IssuesView"
+            relative="org.eclipse.ui.views.ProblemView"
+            relationship="stack"/>
+        <view id="org.sonarlint.eclipse.ui.ServersView"
+            relative="org.eclipse.ui.views.ProblemView"
+            relationship="right"/>
+        <view id="org.sonarlint.eclipse.ui.views.RuleDescriptionWebView"
+            relative="org.eclipse.ui.views.ContentOutline"
+            relationship="stack" visible="false"/>
+        <viewShortcut
+              id="org.sonarlint.eclipse.ui.views.issues.IssuesView">
+        </viewShortcut>
+    </perspectiveExtension>
+    
+    <!-- PDE provided main plug-in development perspective -->
+    <perspectiveExtension
+        targetID="org.eclipse.pde.ui.PDEPerspective">
+        <view id="org.sonarlint.eclipse.ui.views.IssueLocationsView"
+            relative="org.eclipse.ui.views.ContentOutline"
+            relationship="stack" visible="false"/>
+        <view id="org.sonarlint.eclipse.ui.views.issues.IssuesView"
+            relative="org.eclipse.ui.views.ProblemView"
+            relationship="stack"/>
+        <view id="org.sonarlint.eclipse.ui.ServersView"
+            relative="org.eclipse.ui.views.ProblemView"
+            relationship="right"/>
         <view id="org.sonarlint.eclipse.ui.views.RuleDescriptionWebView"
             relative="org.eclipse.ui.views.ContentOutline"
             relationship="stack" visible="false"/>


### PR DESCRIPTION
[SLE-1068](https://sonarsource.atlassian.net/browse/SLE-1068)

For easier onboarding of users we add the SonarQube views to the C/C++ and PDE perspective as well. In order to raise awareness with Connected Mode, the Bindings view was added to all perspectives as well.

See the screenshots appended to the ticket on how this looks like now. This is added to the perspectives initially and not every time - so it is helping the onboarding :partying_face: 

[SLE-1068]: https://sonarsource.atlassian.net/browse/SLE-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ