### PR TITLE
Do not throw exceptions for unsupported charsets

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapterTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapterTest.java
@@ -1,0 +1,65 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) 2015-2025 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.core.internal.resources;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.sonarlint.eclipse.tests.common.SonarTestCase;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultSonarLintFileAdapterTest extends SonarTestCase {
+
+  private static IProject project;
+
+  @BeforeClass
+  public static void importProject() throws IOException, CoreException {
+    project = importEclipseProject("charsets");
+  }
+
+  @Test
+  public void testKnownCharset() {
+    var file = (IFile) project.findMember("known.xml");
+    var adapter = new DefaultSonarLintFileAdapter(new DefaultSonarLintProjectAdapter(project), file);
+    assertEquals(StandardCharsets.UTF_8, adapter.getCharset());
+  }
+
+  @Test
+  public void testUnknownCharset() {
+    var file = (IFile) project.findMember("unknown.xml");
+    var adapter = new DefaultSonarLintFileAdapter(new DefaultSonarLintProjectAdapter(project), file);
+    assertEquals(Charset.defaultCharset(), adapter.getCharset());
+  }
+
+  @Test
+  public void testIllegalCharset() throws CoreException {
+    var file = (IFile) project.findMember("illegal.xml");
+    var adapter = new DefaultSonarLintFileAdapter(new DefaultSonarLintProjectAdapter(project), file);
+    // For illegal encodings Eclipse returns the file's parent default encoding
+    assertEquals(Charset.forName(project.getDefaultCharset()), adapter.getCharset());
+  }
+
+}

--- a/org.sonarlint.eclipse.core.tests/testdata/charsets/illegal.xml
+++ b/org.sonarlint.eclipse.core.tests/testdata/charsets/illegal.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="-"?>

--- a/org.sonarlint.eclipse.core.tests/testdata/charsets/known.xml
+++ b/org.sonarlint.eclipse.core.tests/testdata/charsets/known.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?>

--- a/org.sonarlint.eclipse.core.tests/testdata/charsets/unknown.xml
+++ b/org.sonarlint.eclipse.core.tests/testdata/charsets/unknown.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="foo-bar"?>

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapter.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapter.java
@@ -20,6 +20,7 @@
 package org.sonarlint.eclipse.core.internal.resources;
 
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Objects;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.LocationKind;
@@ -84,10 +85,18 @@ public class DefaultSonarLintFileAdapter implements ISonarLintFile {
 
   @Override
   public Charset getCharset() {
+    String charsetName;
     try {
-      return Charset.forName(file.getCharset());
+      charsetName = file.getCharset();
     } catch (CoreException e) {
       SonarLintLogger.get().error("Unable to determine charset of file " + file, e);
+      return Charset.defaultCharset();
+    }
+
+    try {
+      return Charset.forName(charsetName);
+    } catch (UnsupportedCharsetException e) {
+      SonarLintLogger.get().debug("Unsupported charset " + charsetName + " found in file " + file, e);
       return Charset.defaultCharset();
     }
   }


### PR DESCRIPTION
When there is an XML file in the workspace with a character set which is not supported by the JVM by default, the following exception will be thrown and the initialization of the filesystem is terminated.

```
Feb. 22, 2025 6:28:47 PM org.sonarsource.sonarlint.shaded.org.eclipse.lsp4j.jsonrpc.RemoteEndpoint fallbackResponseError
SCHWERWIEGEND: Internal error: java.nio.charset.UnsupportedCharsetException: foo-bar
java.util.concurrent.CompletionException: java.nio.charset.UnsupportedCharsetException: foo-bar
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.nio.charset.UnsupportedCharsetException: foo-bar
	at java.base/java.nio.charset.Charset.forName(Charset.java:542)
	at org.sonarlint.eclipse.core.internal.resources.DefaultSonarLintFileAdapter.getCharset(DefaultSonarLintFileAdapter.java:88)
	at org.sonarlint.eclipse.core.internal.backend.FileSystemSynchronizer.toFileDto(FileSystemSynchronizer.java:295)
	at org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessRpcClient.lambda$0(SonarLintEclipseHeadlessRpcClient.java:89)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessRpcClient.listFiles(SonarLintEclipseHeadlessRpcClient.java:91)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$listFiles$31(SonarLintRpcClientImpl.java:348)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$requestAsync$1(SonarLintRpcClientImpl.java:124)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 4 more
```

Later during the analysis, some files may not be found, because the above exception has stopped the initialization of the filesystem.

```
SonarLint processing file /test1/src/test1/Main1.java...
Git Repository not found for /home/ole/data/runtime-New_configuration/test1. The path /home/ole/data/runtime-New_configuration/test1 is not in a Git repository
File to analyze was not found in the file system: file:/home/ole/data/runtime-New_configuration/test1/src/test1/Main1.java
Triggering analysis with configuration: [
  baseDir: /home/ole/data/runtime-New_configuration/test1
  extraProperties: {sonar.java.target=21, sonar.java.libraries=/usr/lib/jvm/java-21-openjdk/lib/jrt-fs.jar, sonar.java.enablePreview=false, sonar.java.source=21, sonar.java.binaries=/home/ole/data/runtime-New_configuration/test1/bin, sonar.java.test.binaries=, sonar.java.test.libraries=/usr/lib/jvm/java-21-openjdk/lib/jrt-fs.jar,/home/ole/data/runtime-New_configuration/test1/bin}
  activeRules: [214 python, 24 css, 486 java, 46 Web, 14 xml, 155 php, 267 typescript, 29 secrets, 265 javascript]
  inputFiles: [
  ]
]

No file to analyze
```