### PR TITLE
SLE-1098: Exclude buggy Eclipse PDE files

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
@@ -171,9 +171,11 @@ public class FileSystemSynchronizer implements IResourceChangeListener {
 
     // Immediately rule out files in the VCS and files related to Node.js "metadata" / storage or Python virtual
     // environments. We don't care for these ones no matter if removed, changed, or added!
+    // INFO: We also exclude buggy Eclipse PDE files!
     if (SonarLintUtils.insideVCSFolder(fullPath)
       || SonarLintUtils.isNodeJsRelated(fullPath)
-      || SonarLintUtils.isPythonRelated(fullPath)) {
+      || SonarLintUtils.isPythonRelated(fullPath)
+      || SonarLintUtils.isIncorrectEclipsePDE(fullPath)) {
       return false;
     }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintProjectAdapter.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintProjectAdapter.java
@@ -102,9 +102,11 @@ public class DefaultSonarLintProjectAdapter implements ISonarLintProject {
 
           // Immediately rule out files in the VCS and files related to Node.js "metadata" / storage or Python virtual
           // environments. We don't care for these ones no matter if removed, changed, or added!
+          // INFO: We also exclude buggy Eclipse PDE files!
           if (SonarLintUtils.insideVCSFolder(fullPath)
             || SonarLintUtils.isNodeJsRelated(fullPath)
-            || SonarLintUtils.isPythonRelated(fullPath)) {
+            || SonarLintUtils.isPythonRelated(fullPath)
+            || SonarLintUtils.isIncorrectEclipsePDE(fullPath)) {
             return false;
           }
 

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -296,6 +296,18 @@ public class SonarLintUtils {
     return satisfiesCheck;
   }
 
+  /**
+   *  On macOS/Linux Eclipse PDE while working with Maven/Tycho creates folders starting with "file:/" in every Eclipse
+   *  project that contains a `product` definition. In this folder unpacked parts of plug-ins will be saved and
+   *  therefore triggers a lot of events we don't want to react to.
+   *
+   *  @see <a href="https://sonarsource.atlassian.net/browse/SLE-1098">SLE-1098</a>
+   */
+  public static boolean isIncorrectEclipsePDE(IPath path) {
+    var osString = path.makeAbsolute().toOSString();
+    return osString.contains("/file:/");
+  }
+
   // This can also be used in sub-plug-ins!
   public static String getConfigScopeId(IProject project) {
     return project.getLocationURI().toString();


### PR DESCRIPTION
[SLE-1098](https://sonarsource.atlassian.net/browse/SLE-1098)

See the actual Jira ticket for more information.

Eclipse PDE alongside Maven/Tycho has a bug when using Target Platform definitions and `product` definition files in a project, that a folder is created named `file:` that contains unpacked parts of plug-ins. This triggers a lot of events every time something changes - it consumes a lot of bandwidth and should therefore be ignored.

[SLE-1098]: https://sonarsource.atlassian.net/browse/SLE-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ