### PR TITLE
Skip files with unsupported charsets

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
@@ -21,6 +21,8 @@ package org.sonarlint.eclipse.core.internal.backend;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -291,8 +293,16 @@ public class FileSystemSynchronizer implements IResourceChangeListener {
       fileContent = slFile.getDocument().get();
     }
 
+    Charset charset;
+    try {
+      charset = slFile.getCharset();
+    } catch (UnsupportedCharsetException e) {
+      SonarLintLogger.get().debug("Unsupported charset in file " + slFile, e);
+      return null;
+    }
+
     return new ClientFileDto(slFile.uri(), Paths.get(slFile.getProjectRelativePath()), configScopeId, TestFileClassifier.get().isTest(slFile),
-      slFile.getCharset().name(), fsPath, fileContent, tryDetectLanguage(slFile), true);
+      charset.name(), fsPath, fileContent, tryDetectLanguage(slFile), true);
   }
 
   /**

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapter.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintFileAdapter.java
@@ -114,4 +114,9 @@ public class DefaultSonarLintFileAdapter implements ISonarLintFile {
     return Objects.equals(file, other.file);
   }
 
+  @Override
+  public String toString() {
+    return getName();
+  }
+
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/resource/ISonarLintFile.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/resource/ISonarLintFile.java
@@ -21,6 +21,7 @@ package org.sonarlint.eclipse.core.resource;
 
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.jface.text.IDocument;
 
@@ -45,6 +46,9 @@ public interface ISonarLintFile extends ISonarLintIssuable {
   /**
    * Some analyzers need to read the file from disk so {@link #getDocument()} will not be used, and instead
    * {@link EFS} will be queried for a physical copy of the file, and content will be read using this charset.
+   * 
+   * @throws UnsupportedCharsetException
+   *         If no support for the named charset is available in this instance of the Java virtual machine
    */
   Charset getCharset();
 


### PR DESCRIPTION
Hi @thahnen,

this pull request is a different approach the handle unsupported charsets. Instead of returning a default charset (see #827), which later may case problems when analyzing the file, files with unsupported charsets will be skipped here.

**Problem description**

When there is an XML file in the workspace with a character set which is not supported by the JVM by default, the following exception will be thrown and the initialization of the filesystem is terminated.

```
Feb. 22, 2025 6:28:47 PM org.sonarsource.sonarlint.shaded.org.eclipse.lsp4j.jsonrpc.RemoteEndpoint fallbackResponseError
SCHWERWIEGEND: Internal error: java.nio.charset.UnsupportedCharsetException: foo-bar
java.util.concurrent.CompletionException: java.nio.charset.UnsupportedCharsetException: foo-bar
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.nio.charset.UnsupportedCharsetException: foo-bar
	at java.base/java.nio.charset.Charset.forName(Charset.java:542)
	at org.sonarlint.eclipse.core.internal.resources.DefaultSonarLintFileAdapter.getCharset(DefaultSonarLintFileAdapter.java:88)
	at org.sonarlint.eclipse.core.internal.backend.FileSystemSynchronizer.toFileDto(FileSystemSynchronizer.java:295)
	at org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessRpcClient.lambda$0(SonarLintEclipseHeadlessRpcClient.java:89)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.sonarlint.eclipse.core.internal.backend.SonarLintEclipseHeadlessRpcClient.listFiles(SonarLintEclipseHeadlessRpcClient.java:91)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$listFiles$31(SonarLintRpcClientImpl.java:348)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$requestAsync$1(SonarLintRpcClientImpl.java:124)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 4 more
```

Later during the analysis, some files may not be found, because the above exception has stopped the initialization of the filesystem.

```
SonarLint processing file /test1/src/test1/Main1.java...
Git Repository not found for /home/ole/data/runtime-New_configuration/test1. The path /home/ole/data/runtime-New_configuration/test1 is not in a Git repository
File to analyze was not found in the file system: file:/home/ole/data/runtime-New_configuration/test1/src/test1/Main1.java
Triggering analysis with configuration: [
  baseDir: /home/ole/data/runtime-New_configuration/test1
  extraProperties: {sonar.java.target=21, sonar.java.libraries=/usr/lib/jvm/java-21-openjdk/lib/jrt-fs.jar, sonar.java.enablePreview=false, sonar.java.source=21, sonar.java.binaries=/home/ole/data/runtime-New_configuration/test1/bin, sonar.java.test.binaries=, sonar.java.test.libraries=/usr/lib/jvm/java-21-openjdk/lib/jrt-fs.jar,/home/ole/data/runtime-New_configuration/test1/bin}
  activeRules: [214 python, 24 css, 486 java, 46 Web, 14 xml, 155 php, 267 typescript, 29 secrets, 265 javascript]
  inputFiles: [
  ]
]

No file to analyze
```