### PR TITLE
SLE-1109: Add option for BOM to work correctly with Tycho

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <sonar.java.source>11</sonar.java.source>
     <sonar.java.target>11</sonar.java.target>
     <sonar.exclusions>**/.tycho-consumer-pom.xml</sonar.exclusions>
+    <sonar.sca.mavenOptions>-Dtycho.target.eager=true</sonar.sca.mavenOptions>
 
     <!-- Global properties -->
     <jarsigner.skip>true</jarsigner.skip>


### PR DESCRIPTION
[SLE-1109](https://sonarsource.atlassian.net/browse/SLE-1109)

For the SonarQube Server analysis we require a new property to tweak the Bill of Material generation that is currently not working with Maven/Tycho out of the box.

For more context, see [this thread](https://discuss.sonarsource.com/t/bom-does-not-work-for-maven-tycho-builds/21816).

[SLE-1109]: https://sonarsource.atlassian.net/browse/SLE-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ