### PR TITLE
SLE-1113: Rely on Eclipse Mylyn of released version

### DIFF
--- a/.cirrus.default.yml
+++ b/.cirrus.default.yml
@@ -364,8 +364,6 @@ qa_standaloneMode_task:
     - env:
         TARGET_PLATFORM: 'oldest-java-11_e417'
     - env:
-        TARGET_PLATFORM: 'latest-java-17_e431'
-    - env:
         TARGET_PLATFORM: 'latest-java-21'
   <<: *SETUP_MAVEN_CACHE_QA
   download_staged_update_site_script: |

--- a/its/org.sonarlint.eclipse.its.connected.sq/its.connected.sq.product
+++ b/its/org.sonarlint.eclipse.its.connected.sq/its.connected.sq.product
@@ -36,7 +36,7 @@
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.m2e.feature"/>
       <feature id="org.eclipse.buildship"/>
-      <feature id="org.eclipse.mylyn.commons"/>
+      <feature id="org.eclipse.mylyn.commons.feature"/>
       <feature id="org.sonarlint.eclipse.feature"/>
    </features>
 

--- a/target-platforms/latest-java-17_e431.target
+++ b/target-platforms/latest-java-17_e431.target
@@ -13,6 +13,7 @@
       <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="0.0.0" />
       <unit id="org.eclipse.pde.feature.group" version="0.0.0" />
       <unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0" />
+      <unit id="org.eclipse.mylyn.commons.feature.feature.group" version="0.0.0" />
       <!-- Needed to build the test environment -->
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
       <repository location="https://download.eclipse.org/releases/2024-03" />
@@ -22,11 +23,6 @@
       <!-- Mirror of the defunct "https://download.eclipse.org/reddeer/releases/latest/" -->
       <repository location="https://repox.jfrog.io/artifactory/reddeer/releases/latest/" />
       <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="0.0.0" />
-    </location>
-    
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="0.0.0" />
-      <repository location="https://download.eclipse.org/mylyn/updates/release/" />
     </location>
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[SLE-1113](https://sonarsource.atlassian.net/browse/SLE-1113)

Don't rely on the latest Eclipse Mylyn version for the latest Java 17 based target platform but the one linked to that Eclipse IDE release.

Consequence is that the actual feature name of Mylyn is inconsistent and had to be updated in the `product` definition of the Connected Mode ITs against SonarQube Server (all running with Java 17).

The Standalone Mode ITs on the CI also don't run against Java 17 anymore as we are testing both the oldest and the newest supported version, this was a leftover of July last year when the Eclipse IDE moved from Java 17 to 21.

[SLE-1113]: https://sonarsource.atlassian.net/browse/SLE-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ