### PR TITLE
SLE-1121: Exclude files with unsupported charset (or encoding)

### DIFF
--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
@@ -81,6 +81,7 @@ import org.sonarlint.eclipse.its.shared.reddeer.preferences.FileAssociationsPref
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.RuleConfigurationPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.SonarLintPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.views.OnTheFlyView;
+import org.sonarlint.eclipse.its.shared.reddeer.views.ReportView;
 import org.sonarlint.eclipse.its.shared.reddeer.views.SonarLintConsole;
 import org.sonarlint.eclipse.its.shared.reddeer.views.SonarLintConsole.ShowConsoleOption;
 import org.sonarlint.eclipse.its.shared.reddeer.views.SonarLintIssueMarker;
@@ -312,6 +313,12 @@ public abstract class AbstractSonarLintTest {
           .extracting(SonarLintIssueMarker::getDescription, SonarLintIssueMarker::getResource, SonarLintIssueMarker::getCreationDate)
           .containsOnly(markers);
       });
+  }
+
+  protected void waitForSonarLintReportIssues(ReportView view, int issues) {
+    Awaitility.await()
+      .atMost(20, TimeUnit.SECONDS)
+      .untilAsserted(() -> assertThat(view.getItems()).hasSize(issues));
   }
 
   protected static final void importExistingProjectIntoWorkspace(String relativePathFromProjectsFolder, boolean isGradle) {

--- a/its/projects/UnsupportedCharset/.project
+++ b/its/projects/UnsupportedCharset/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>UnsupportedCharset</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>

--- a/its/projects/UnsupportedCharset/a.py
+++ b/its/projects/UnsupportedCharset/a.py
@@ -1,0 +1,1 @@
+# TODO: Fill me with content

--- a/its/projects/UnsupportedCharset/din_66003.xml
+++ b/its/projects/UnsupportedCharset/din_66003.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="DIN_66003"?>

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/FileSystemSynchronizer.java
@@ -201,6 +201,10 @@ public class FileSystemSynchronizer implements IResourceChangeListener {
       return true;
     }
 
+    if (!SonarLintUtils.hasSupportedCharset(slFile)) {
+      return false;
+    }
+
     var project = slFile.getProject();
     Set<IPath> exclusions;
     if (SonarLintCorePlugin.loadConfig(project).isIndexingBasedOnEclipsePlugIns()) {

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintProjectAdapter.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/resources/DefaultSonarLintProjectAdapter.java
@@ -129,6 +129,10 @@ public class DefaultSonarLintProjectAdapter implements ISonarLintProject {
           var sonarLintFile = SonarLintUtils.adapt(resource, ISonarLintFile.class,
             "[DefaultSonarLintProjectAdapter#files] Try get file of resource '" + resource + "'");
           if (sonarLintFile != null) {
+            if (!SonarLintUtils.hasSupportedCharset(sonarLintFile)) {
+              return false;
+            }
+
             result.add(sonarLintFile);
           }
           return true;

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -324,4 +324,19 @@ public class SonarLintUtils {
   public static String getConfigScopeId(IProject project) {
     return project.getLocationURI().toString();
   }
+
+  /**
+   *  Some charsets might not be supported or available in the JVM. When such a file is encountered, the plug-in
+   *  currently throws an exception. These files should be excluded completely from indexing and the analysis.
+   */
+  public static boolean hasSupportedCharset(ISonarLintFile file) {
+    try {
+      file.getCharset();
+      return true;
+    } catch (Exception err) {
+      SonarLintLogger.get().traceIdeMessage("[SonarLintUtils#hasSupportedCharset] Unsupported charset/encoding for file: "
+        + file.getName(), err);
+      return false;
+    }
+  }
 }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/resource/ISonarLintFile.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/resource/ISonarLintFile.java
@@ -19,8 +19,10 @@
  */
 package org.sonarlint.eclipse.core.resource;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.jface.text.IDocument;
 
@@ -45,6 +47,9 @@ public interface ISonarLintFile extends ISonarLintIssuable {
   /**
    * Some analyzers need to read the file from disk so {@link #getDocument()} will not be used, and instead
    * {@link EFS} will be queried for a physical copy of the file, and content will be read using this charset.
+   *
+   * @throws UnsupportedCharsetException if the JVM does not offer support for the named charset
+   * @throws UnsupportedEncodingException if the JVM specific XML loader does not support the encoding
    */
   Charset getCharset();
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
@@ -219,7 +219,12 @@ public final class PlatformUtils {
         var file = ((IFileEditorInput) input).getFile();
         var slFile = SonarLintUtils.adapt(file, ISonarLintFile.class,
           "[PlatformUtils#doIfSonarLintFileInEditor] Try get file of editor input '" + file.getName() + "'");
-        if (slFile != null) {
+
+        // We have to check the charset (and internally the encoding is also checked for XML files) here as well as
+        // for unsupported charsets the Eclipse builtin editor already fails to open the file but will trigger the
+        // "IPartListener2#partOpened" nevertheless. When Eclipse (and internally the JVM) cannot even handle the file,
+        // we don't even try to do so.
+        if (slFile != null && SonarLintUtils.hasSupportedCharset(slFile)) {
           consumer.accept(slFile, editorPart);
         }
       }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SelectionUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/SelectionUtils.java
@@ -117,7 +117,10 @@ public final class SelectionUtils {
     // SLE-503 Start with the more specific to the more generic
     var file = SonarLintUtils.adapt(elem, ISonarLintFile.class,
       "[SelectionUtils#collectFiles] Try get file of object '" + elem.toString() + "'");
-    if (file != null) {
+
+    // We have to check the charset (and internally the encoding is also checked for XML files) here as well as
+    // for unsupported charsets the manual (forced) analysis should also not start at all.
+    if (file != null && SonarLintUtils.hasSupportedCharset(file)) {
       selectedFiles.add(file);
       return;
     }


### PR DESCRIPTION
When a file is in the project with an unsupported charset (or encoding) it should be excluded from indexing and the analysis. This should not impact other files or part of the experience.

Added an IT to test that everything still works as expected.

This is a adjusted PR for triggering the CI for the external contribution coming from #832 