### PR TITLE
SLE-1125: Handle index exclusions correctly with JDT

### DIFF
--- a/its/projects/java/TestOutputEqualsProject/.classpath
+++ b/its/projects/java/TestOutputEqualsProject/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path=""/>
+</classpath>

--- a/its/projects/java/TestOutputEqualsProject/.project
+++ b/its/projects/java/TestOutputEqualsProject/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>TestOutputEqualsProject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/its/projects/java/TestOutputEqualsProject/.settings/org.eclipse.core.resources.prefs
+++ b/its/projects/java/TestOutputEqualsProject/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/its/projects/java/TestOutputEqualsProject/.settings/org.eclipse.jdt.core.prefs
+++ b/its/projects/java/TestOutputEqualsProject/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/its/projects/java/TestOutputEqualsProject/Test.py
+++ b/its/projects/java/TestOutputEqualsProject/Test.py
@@ -1,0 +1,1 @@
+# TODO: aaaa

--- a/its/projects/java/TestOutputEqualsProject/src/aaa/Main.java
+++ b/its/projects/java/TestOutputEqualsProject/src/aaa/Main.java
@@ -1,0 +1,10 @@
+package aaa;
+
+public class Main {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+
+	}
+
+}


### PR DESCRIPTION
[SLE-1125](https://sonarsource.atlassian.net/browse/SLE-1125)

When a JDT project has configured the default output directory to point to the project / base directory, don't exclude the whole project from indexing and the analysis.

Added an integration test to mimic such a corner case and to see that it still behaves correctly.

[SLE-1125]: https://sonarsource.atlassian.net/browse/SLE-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ