### PR TITLE
SLE-1122: Don't pollute Sentry when running UTs/ITs

### DIFF
--- a/its/org.sonarlint.eclipse.its.cdt/ITs CDT.launch
+++ b/its/org.sonarlint.eclipse.its.cdt/ITs CDT.launch
@@ -20,6 +20,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="SONARSOURCE_DOGFOODING" value="0"/>
+    </mapAttribute>
     <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
     </listAttribute>

--- a/its/org.sonarlint.eclipse.its.connected.sc/ITs SQ-C EU.launch
+++ b/its/org.sonarlint.eclipse.its.connected.sc/ITs SQ-C EU.launch
@@ -20,6 +20,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="SONARSOURCE_DOGFOODING" value="0"/>
+    </mapAttribute>
     <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
     </listAttribute>

--- a/its/org.sonarlint.eclipse.its.connected.sc/ITs SQ-C US.launch
+++ b/its/org.sonarlint.eclipse.its.connected.sc/ITs SQ-C US.launch
@@ -20,6 +20,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="SONARSOURCE_DOGFOODING" value="0"/>
+    </mapAttribute>
     <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
     </listAttribute>

--- a/its/org.sonarlint.eclipse.its.connected.sq/ITs SQ-S.launch
+++ b/its/org.sonarlint.eclipse.its.connected.sq/ITs SQ-S.launch
@@ -20,6 +20,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="SONARSOURCE_DOGFOODING" value="0"/>
+    </mapAttribute>
     <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.sonarlint.eclipse.its.connected.sq"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -194,6 +194,11 @@
           <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
 
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          
+          <environmentVariables>
+            <SONARSOURCE_DOGFOODING>0</SONARSOURCE_DOGFOODING>
+          </environmentVariables>
+          
           <systemProperties>
             <target.platform>${target.platform}</target.platform>
             <sonar.runtimeVersion>${sonar.runtimeVersion}</sonar.runtimeVersion>

--- a/org.sonarlint.eclipse.core.tests/Unit Tests.launch
+++ b/org.sonarlint.eclipse.core.tests/Unit Tests.launch
@@ -20,6 +20,9 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="SONARSOURCE_DOGFOODING" value="0"/>
+    </mapAttribute>
     <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
         <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
     </listAttribute>

--- a/org.sonarlint.eclipse.core.tests/pom.xml
+++ b/org.sonarlint.eclipse.core.tests/pom.xml
@@ -29,6 +29,10 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
+          <environmentVariables>
+            <SONARSOURCE_DOGFOODING>0</SONARSOURCE_DOGFOODING>
+          </environmentVariables>
+          
           <!-- We cannot have it in target/work as well due to Git ignored files not being analyzed! -->
           <osgiDataDirectory>${java.io.tmpdir}/SLE-${maven.build.timestamp}</osgiDataDirectory>
           


### PR DESCRIPTION
[SLE-1122](https://sonarsource.atlassian.net/browse/SLE-1122)

Sentry should only gather data on production environments and should not be polluted by UTs/ITs (running locally or on the CI).

[SLE-1122]: https://sonarsource.atlassian.net/browse/SLE-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ