### PR TITLE
SLE-1133: Correctly exclude files from indexing

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -273,10 +273,10 @@ public class SonarLintUtils {
    *  Here we catch Git, Mercurial, and Apache Subversion as they're the most common ones.
    */
   public static boolean insideVCSFolder(IPath path) {
-    var osString = path.makeAbsolute().toOSString();
-    var satisfiesCheck = osString.contains(".git");
-    satisfiesCheck = satisfiesCheck || osString.contains(".hg");
-    satisfiesCheck = satisfiesCheck || osString.contains(".svn");
+    var osString = path.makeAbsolute().toOSString().replace("\\", "/");
+    var satisfiesCheck = osString.contains("/.git/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/.hg/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/.svn/");
     return satisfiesCheck;
   }
 
@@ -286,9 +286,9 @@ public class SonarLintUtils {
    *  plug-in to rely on for getting these values.
    */
   public static boolean isNodeJsRelated(IPath path) {
-    var osString = path.makeAbsolute().toOSString();
-    var satisfiesCheck = osString.contains("node_modules");
-    satisfiesCheck = satisfiesCheck || osString.contains("package-lock.json");
+    var osString = path.makeAbsolute().toOSString().replace("\\", "/");
+    var satisfiesCheck = osString.contains("/node_modules/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/package-lock.json");
     return satisfiesCheck;
   }
 
@@ -300,11 +300,11 @@ public class SonarLintUtils {
    *  Here we catch the most common Python virtual environment names.
    */
   public static boolean isPythonRelated(IPath path) {
-    var osString = path.makeAbsolute().toOSString();
-    var satisfiesCheck = osString.contains("venv");
-    satisfiesCheck = satisfiesCheck || osString.contains("pyenv");
-    satisfiesCheck = satisfiesCheck || osString.contains("pyvenv");
-    satisfiesCheck = satisfiesCheck || osString.contains("virtualenv");
+    var osString = path.makeAbsolute().toOSString().replace("\\", "/");
+    var satisfiesCheck = osString.contains("/venv/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/pyenv/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/pyvenv/");
+    satisfiesCheck = satisfiesCheck || osString.contains("/virtualenv/");
     return satisfiesCheck;
   }
 


### PR DESCRIPTION
[SLE-1133](https://sonarsource.atlassian.net/browse/SLE-1133)

We currently exclude files from VCS, Node.js and Python virtual environments from indexing (and therefore the analysis) to optimize our plug-in.

We should do it correctly by checking for the actual files and folder and not whether an excluded identifier is part of the string of the absolute path.

[SLE-1133]: https://sonarsource.atlassian.net/browse/SLE-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ