### PR TITLE
SLE-1134: Show correct legacy Severity grouping icons

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintImages.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintImages.java
@@ -132,7 +132,7 @@ public final class SonarLintImages {
       if (matchingStatus != null) {
         matchingStatusImage = matchingStatusToImageDescriptor(matchingStatus, isResolved);
       }
-      var severityImage = getImpactSeverityImageDescriptor(issueSeverity.toLowerCase(Locale.ENGLISH));
+      var severityImage = getImpactSeverityImageDescriptor(issueSeverity);
       ImageDescriptor typeImage = null;
       if (type != null) {
         typeImage = createImageDescriptor("type/" + type.toLowerCase(Locale.ENGLISH) + ".png");


### PR DESCRIPTION
[SLE-1134](https://sonarsource.atlassian.net/browse/SLE-1134)

When moving between the old and new severity icons for Standard Mode it was missed to correctly handle the grouping icons which currently falls back to the one of the information severity.

[SLE-1134]: https://sonarsource.atlassian.net/browse/SLE-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ