### PR TITLE
SLE-1147 Make sure all files used for unit tests have LF as EOL.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 org.sonarlint.eclipse.runtime/META-INF/MANIFEST.MF  eol=crlf
 org.sonarlint.eclipse.wsclient/META-INF/MANIFEST.MF eol=crlf
 
-#Prevent Git on Windows to change LF to CRLF on this file
+#Prevent Git on Windows to change LF to CRLF on this files
 org.sonarlint.eclipse.core.tests/testdata/SimpleProject/src/main/java/ViolationOnFile.java eol=lf
+org.sonarlint.eclipse.core.tests/testdata/SimpleProject/src/main/java/com/quickfix/FileWithQuickFixes.java eol=lf
+org.sonarlint.eclipse.core.tests/testdata/*.java eol=lf


### PR DESCRIPTION
[SLE-1147](https://sonarsource.atlassian.net/browse/SLE-1147)

Make sure all files used for unit tests have LF as EOL. This should prevent the unit tests to fail on Windows machines.

[SLE-1147]: https://sonarsource.atlassian.net/browse/SLE-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ