### PR TITLE
SLE-1148: Wait for SLOOP to shutdown gracefully

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -407,7 +407,7 @@ public class SonarLintBackendService {
       connectionSynchronizer = null;
     }
     if (backend != null) {
-      backend.shutdown();
+      backend.shutdown().join();
     }
     backend = null;
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -407,7 +409,11 @@ public class SonarLintBackendService {
       connectionSynchronizer = null;
     }
     if (backend != null) {
-      backend.shutdown().join();
+      try {
+        backend.shutdown().get(10, TimeUnit.SECONDS);
+      } catch (InterruptedException | ExecutionException | TimeoutException err) {
+        SonarLintLogger.get().error("Unable to shutdown the SonarLint Core RPC server", err);
+      }
     }
     backend = null;
   }


### PR DESCRIPTION
[SLE-1148](https://sonarsource.atlassian.net/browse/SLE-1148)

This was removed a while ago due to flakyness and it sometimes prevented the IDE from shutting down as it was waiting for SonarQube for Eclipse. Let's introduce it again and see.

[SLE-1148]: https://sonarsource.atlassian.net/browse/SLE-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ