### PR TITLE
SLE-803: Invalid organization should not render wizard unusabled

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
@@ -195,6 +195,19 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
 
     assertThat(organizationsPage.getOrganization()).isEqualTo(SONARCLOUD_ORGANIZATION_KEY);
 
+    // Check that when entering an invalid organization moving forward is blocked
+    var invalidOrganization = "thisOrganizationDoesNotExist";
+    organizationsPage.setOrganization(invalidOrganization);
+    assertThat(wizard.isNextEnabled()).isTrue();
+    wizard.next();
+    new WaitUntil(new DialogMessageIsExpected(wizard, "No organizations found for key: " + invalidOrganization));
+
+    wizard.back();
+    assertThat(wizard.isNextEnabled()).isTrue();
+    wizard.next();
+
+    organizationsPage = new ServerConnectionWizard.OrganizationsPage(wizard);
+    organizationsPage.waitForOrganizationsToBeFetched();
     organizationsPage.setOrganization(SONARCLOUD_ORGANIZATION_KEY);
     assertThat(wizard.isNextEnabled()).isTrue();
     wizard.next();

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/AbstractConnectionWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/AbstractConnectionWizard.java
@@ -145,7 +145,15 @@ public abstract class AbstractConnectionWizard extends Wizard implements INewWiz
     return resultServer;
   }
 
-  protected boolean testConnection(boolean doNotTestOrganization) {
+  protected boolean testToken() {
+    return testConnection(true);
+  }
+
+  protected boolean testOrganization() {
+    return testConnection(false);
+  }
+
+  private boolean testConnection(boolean doNotTestOrganization) {
     var currentPage = getContainer().getCurrentPage();
     var response = new AtomicReference<ValidateConnectionResponse>();
     try {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ServerConnectionWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ServerConnectionWizard.java
@@ -106,7 +106,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
   protected void actualHandlePageChanging(PageChangingEvent event) {
     var currentPage = (WizardPage) event.getCurrentPage();
     var advance = getNextPage(currentPage) == event.getTargetPage();
-    if (advance && currentPage == tokenPage && !testConnection(null)) {
+    if (advance && currentPage == tokenPage && !testConnection(true)) {
       event.doit = false;
       return;
     }
@@ -114,7 +114,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
       event.doit = tryLoadOrganizations(currentPage);
       return;
     }
-    if (advance && currentPage == orgPage && !testConnection(model.getOrganization())) {
+    if (advance && currentPage == orgPage && !testConnection(false)) {
       event.doit = false;
     }
   }
@@ -184,7 +184,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
   @Override
   protected boolean actualPerformFinish() {
     try {
-      if (model.isEdit() && !testConnection(model.getOrganization())) {
+      if (model.isEdit() && !testConnection(false)) {
         return false;
       }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ServerConnectionWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ServerConnectionWizard.java
@@ -106,7 +106,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
   protected void actualHandlePageChanging(PageChangingEvent event) {
     var currentPage = (WizardPage) event.getCurrentPage();
     var advance = getNextPage(currentPage) == event.getTargetPage();
-    if (advance && currentPage == tokenPage && !testConnection(true)) {
+    if (advance && currentPage == tokenPage && !testToken()) {
       event.doit = false;
       return;
     }
@@ -114,7 +114,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
       event.doit = tryLoadOrganizations(currentPage);
       return;
     }
-    if (advance && currentPage == orgPage && !testConnection(false)) {
+    if (advance && currentPage == orgPage && !testOrganization()) {
       event.doit = false;
     }
   }
@@ -184,7 +184,7 @@ public class ServerConnectionWizard extends AbstractConnectionWizard {
   @Override
   protected boolean actualPerformFinish() {
     try {
-      if (model.isEdit() && !testConnection(false)) {
+      if (model.isEdit() && !testOrganization()) {
         return false;
       }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/SuggestConnectionWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/SuggestConnectionWizard.java
@@ -53,13 +53,13 @@ public class SuggestConnectionWizard extends AbstractConnectionWizard {
   @Override
   protected boolean actualCanFinish() {
     // INFO: testConnection(...) won't fail if model.getUsername(...) is null -.-
-    return model.getUsername() != null && testConnection(model.getOrganization());
+    return model.getUsername() != null && testConnection(false);
   }
 
   @Override
   protected boolean actualPerformFinish() {
     try {
-      if (!testConnection(model.getOrganization())) {
+      if (!testConnection(false)) {
         return false;
       }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/SuggestConnectionWizard.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/SuggestConnectionWizard.java
@@ -53,13 +53,13 @@ public class SuggestConnectionWizard extends AbstractConnectionWizard {
   @Override
   protected boolean actualCanFinish() {
     // INFO: testConnection(...) won't fail if model.getUsername(...) is null -.-
-    return model.getUsername() != null && testConnection(false);
+    return model.getUsername() != null && testOrganization();
   }
 
   @Override
   protected boolean actualPerformFinish() {
     try {
-      if (!testConnection(false)) {
+      if (!testOrganization()) {
         return false;
       }
 


### PR DESCRIPTION
[SLE-803](https://sonarsource.atlassian.net/browse/SLE-803)

The organization is not taken into account when checking for the token anymore, which led to incorrect behavior and rendered the wizard unusable.

[SLE-803]: https://sonarsource.atlassian.net/browse/SLE-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ