### PR TITLE
SLE-1130: Rely on Java 17 and RedDeer 4.7.1 for oldest ITs

### DIFF
--- a/target-platforms/oldest-java-11_e417.target
+++ b/target-platforms/oldest-java-11_e417.target
@@ -19,7 +19,7 @@
     
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="0.0.0" />
-      <repository location="https://binaries.sonarsource.com/RedDeer/releases/4.2.1.93/" />
+      <repository location="https://binaries.sonarsource.com/RedDeer/releases/4.7.1.83/" />
     </location>
     
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,runtime" includeSource="true" missingManifest="error" type="Maven">
@@ -38,5 +38,5 @@
       <repository location="https://download.eclipse.org/buildship/updates/e417/releases/3.x" />
     </location>
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11" />
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />
 </target>


### PR DESCRIPTION
[SLE-1130](https://sonarsource.atlassian.net/browse/SLE-1130)

Despite this being the oldest Eclipse IDE we support, build with Java 11, we run the ITs on a Java 17 runtime to make use of the Eclipse RedDeer 4.7.1 (forked version).
And with that we only have to maintain the one version of the Eclipse RedDeer fork :partying_face: 

[SLE-1130]: https://sonarsource.atlassian.net/browse/SLE-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ