### PR TITLE
SLE-1157: Don't analyze when a quick fix was applied

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/TriggerType.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/TriggerType.java
@@ -27,7 +27,6 @@ public enum TriggerType {
   EDITOR_CHANGE("Editor change", ServerIssueFetchStrategy.DONT_FETCH),
   BINDING_CHANGE("Binding change", ServerIssueFetchStrategy.FETCH),
   STANDALONE_CONFIG_CHANGE("Standalone config change", ServerIssueFetchStrategy.DONT_FETCH),
-  QUICK_FIX("Quick fix", ServerIssueFetchStrategy.DONT_FETCH),
   AFTER_RESOLVE("After resolve", ServerIssueFetchStrategy.DONT_FETCH);
 
   /** For the analysis out of process this information is required */


### PR DESCRIPTION
[SLE-1157](https://sonarsource.atlassian.net/browse/SLE-1157)

This does not make sense due to the fact that when applying a quick fix the file is not saved and therefore the analysis runs on the pre-quick-fix-applied file.

This is a useless analysis. And in anticipation of the upcoming changes to the analysis triggering API of SonarLint Core this is removed to have less confusion.

[SLE-1157]: https://sonarsource.atlassian.net/browse/SLE-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ