### PR TITLE
SLE-1159: Trigger analysis of opened files on analysis properties change

### DIFF
--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/AnalyzerPropertiesPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/AnalyzerPropertiesPreferences.java
@@ -1,0 +1,86 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2025 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.preferences;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.reddeer.core.reference.ReferencedComposite;
+import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyPage;
+import org.eclipse.reddeer.swt.impl.button.OkButton;
+import org.eclipse.reddeer.swt.impl.button.PushButton;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+import org.eclipse.reddeer.swt.impl.table.DefaultTable;
+import org.eclipse.reddeer.swt.impl.text.DefaultText;
+
+public class AnalyzerPropertiesPreferences extends PropertyPage {
+  private static final String NAME_COL = "Name";
+  private static final String VALUE_COL = "Value";
+
+  public AnalyzerPropertiesPreferences(ReferencedComposite composite) {
+    super(composite, new String[] {"SonarQube", "Analyzer Properties"});
+  }
+
+  public void add(String name, String value) {
+    new PushButton(referencedComposite, "New...").click();
+
+    var shell = new DefaultShell("New property");
+    var nameInput = new DefaultText(shell, 0);
+    nameInput.setText(name);
+    var valueInput = new DefaultText(shell, 1);
+    valueInput.setText(value);
+
+    new OkButton().click();
+  }
+
+  public List<AnalyzerProperty> getProperties() {
+    var table = new DefaultTable(referencedComposite);
+    return table.getItems().stream()
+      .map(i -> new AnalyzerProperty(
+        i.getText(table.getHeaderIndex(NAME_COL)),
+        i.getText(table.getHeaderIndex(VALUE_COL))))
+      .collect(Collectors.toList());
+  }
+
+  public void clear() {
+    var table = new DefaultTable(referencedComposite);
+    for (var item : table.getItems()) {
+      table.select(table.indexOf(item));
+      new PushButton(referencedComposite, "Remove").click();
+    }
+  }
+
+  public static class AnalyzerProperty {
+    private final String name;
+    private final String value;
+
+    public AnalyzerProperty(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/AnalyzerPropertiesTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/AnalyzerPropertiesTest.java
@@ -1,0 +1,84 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2025 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.standalone;
+
+import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyDialog;
+import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
+import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.junit.After;
+import org.junit.Test;
+import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
+import org.sonarlint.eclipse.its.shared.reddeer.preferences.AnalyzerPropertiesPreferences;
+import org.sonarlint.eclipse.its.shared.reddeer.views.OnTheFlyView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class AnalyzerPropertiesTest extends AbstractSonarLintTest {
+  @After
+  public void clearGlobalAnalyzerProperties() {
+    var preferenceDialog = new WorkbenchPreferenceDialog();
+    preferenceDialog.open();
+
+    var analyzerPropertiesPreferences = new AnalyzerPropertiesPreferences(preferenceDialog);
+    preferenceDialog.select(analyzerPropertiesPreferences);
+
+    analyzerPropertiesPreferences.clear();
+    preferenceDialog.ok();
+  }
+
+  @Test
+  public void test_analyzer_properties_trigger_analysis() {
+    new JavaPerspective().open();
+    var rootProject = importExistingProjectIntoWorkspace("java/java-simple", "java-simple");
+
+    var issuesView = new OnTheFlyView();
+    issuesView.open();
+
+    var helloFile = rootProject.getResource("src", "hello", "Hello.java");
+    openFileAndWaitForAnalysisCompletion(helloFile);
+
+    waitForSonarLintMarkers(issuesView,
+      tuple("Replace this use of System.out by a logger.", "Hello.java", "few seconds ago"));
+
+    // i) Change global properties
+    var preferenceDialog = new WorkbenchPreferenceDialog();
+    preferenceDialog.open();
+
+    var analyzerPropertiesPreferences = new AnalyzerPropertiesPreferences(preferenceDialog);
+    preferenceDialog.select(analyzerPropertiesPreferences);
+
+    analyzerPropertiesPreferences.add("sonar.java.fileByFile", "true");
+    assertThat(analyzerPropertiesPreferences.getProperties().size()).isEqualTo(1);
+    doAndWaitForSonarLintAnalysisJob(preferenceDialog::ok);
+
+    // ii) Change project properties
+    rootProject.select();
+    var projectPreferenceDialog = new PropertyDialog(rootProject.getName());
+    projectPreferenceDialog.open();
+
+    analyzerPropertiesPreferences = new AnalyzerPropertiesPreferences(projectPreferenceDialog);
+    projectPreferenceDialog.select(analyzerPropertiesPreferences);
+
+    analyzerPropertiesPreferences.add("sonar.java.fileByFile", "false");
+    assertThat(analyzerPropertiesPreferences.getProperties().size()).isEqualTo(1);
+    doAndWaitForSonarLintAnalysisJob(projectPreferenceDialog::ok);
+  }
+}

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -165,14 +165,18 @@ public class SonarLintGlobalConfiguration {
   public static List<SonarLintProperty> getExtraPropertiesForLocalAnalysis(ISonarLintProject project) {
     var props = new ArrayList<SonarLintProperty>();
     // First add all global properties
-    var globalExtraArgs = getPreferenceString(PREF_EXTRA_ARGS);
-    props.addAll(deserializeExtraProperties(globalExtraArgs));
+    props.addAll(getGlobalExtraProperties());
 
     // Then add project properties
     var sonarProject = SonarLintCorePlugin.loadConfig(project);
     props.addAll(sonarProject.getExtraProperties());
 
     return props;
+  }
+
+  public static List<SonarLintProperty> getGlobalExtraProperties() {
+    var globalExtraArgs = getPreferenceString(PREF_EXTRA_ARGS);
+    return deserializeExtraProperties(globalExtraArgs);
   }
 
   public static List<SonarLintProperty> deserializeExtraProperties(@Nullable String property) {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintExtraArgumentsPreferenceAndPropertyPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/properties/SonarLintExtraArgumentsPreferenceAndPropertyPage.java
@@ -413,10 +413,13 @@ public class SonarLintExtraArgumentsPreferenceAndPropertyPage extends AbstractLi
     } else {
       var projectConfig = getProjectConfig();
       if (projectConfig != null) {
-        projectConfig.getExtraProperties().clear();
-        projectConfig.getExtraProperties().addAll(sonarProperties);
-        SonarLintCorePlugin.saveConfig(getProject(), projectConfig);
-        AnalysisJobsScheduler.scheduleAnalysisOfOpenFiles(getProject(), TriggerType.STANDALONE_CONFIG_CHANGE);
+        var previousProperties = projectConfig.getExtraProperties();
+        if (!sonarProperties.equals(previousProperties)) {
+          projectConfig.getExtraProperties().clear();
+          projectConfig.getExtraProperties().addAll(sonarProperties);
+          SonarLintCorePlugin.saveConfig(getProject(), projectConfig);
+          AnalysisJobsScheduler.scheduleAnalysisOfOpenFiles(getProject(), TriggerType.STANDALONE_CONFIG_CHANGE);
+        }
       }
     }
 


### PR DESCRIPTION
[SLE-1159](https://sonarsource.atlassian.net/browse/SLE-1159)

When the analysis properties are changed for either the project or globally, trigger a new (automatic) analysis of the opened files to refresh based on the user changes.

[SLE-1159]: https://sonarsource.atlassian.net/browse/SLE-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ