### PR TITLE
SLE-1167: Remove analysis completion method and deprecate EP

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/analysis/IAnalysisConfigurator.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/analysis/IAnalysisConfigurator.java
@@ -44,7 +44,10 @@ public interface IAnalysisConfigurator {
 
   /**
    * This method is called after analysis is finished. Can be used to perform some cleanup.
+   *
+   * @deprecated because the analysis is asynchronous, third parties implementing this should rather rely on a scheduled removal
    */
+  @Deprecated(since = "11.6", forRemoval = true)
   default void analysisComplete(IPostAnalysisContext context, IProgressMonitor monitor) {
     // Do nothing by default
   }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/analysis/IPostAnalysisContext.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/analysis/IPostAnalysisContext.java
@@ -24,7 +24,9 @@ import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 
 /**
  * @since 3.0
+ * @deprecated because {@link IAnalysisConfigurator#analysisComplete()} is deprecated
  */
+@Deprecated(since = "11.6", forRemoval = true)
 public interface IPostAnalysisContext {
 
   ISonarLintProject getProject();


### PR DESCRIPTION
[SLE-1167](https://sonarsource.atlassian.net/browse/SLE-1167)

Since the analysis is asynchronous nowadays, the "AnalyzeProjectJob#analysisCompleted" did not make sense anymore - as the analysis request was only handed over to SLCORE, but not finished.

The extension point method in the background did not make sense anymore and should be replaced on the implementing side (e.g. by a scheduled cleanup). The related logic for that was therefore deprecated to be removed with the next major release.

## Extension Points Changes

| Extension point | Method | Removed or added? | Why? |
| --- | --- | --- | --- |
|  *org.sonarlint.eclipse.core.analysisConfigurator* | [org.sonarlint.eclipse.core.analysis.IAnalysisConfigurator#analysisComplete(IPostAnalysisContext, IProgressMonitor)](https://github.com/SonarSource/sonarlint-eclipse/blob/11.6.0.xxxxx/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/analysis/IAnalysisConfigurator.java#L45-L53) |  Removed (deprecated) | This will not raise any events any longer and it's marked for removal. The analysis is handled by SLCore and it won't notify about completion. Third parties implementing this extension point should rather rely on a scheduled removal. |

[SLE-1167]: https://sonarsource.atlassian.net/browse/SLE-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ