### PR TITLE
SLE-1181 chore: use the renamed sonar.sca.exclusions property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <sonar.java.target>11</sonar.java.target>
     <sonar.exclusions>**/.tycho-consumer-pom.xml</sonar.exclusions>
     <sonar.sca.mavenOptions>-Dtycho.target.eager=true</sonar.sca.mavenOptions>
-    <sonar.sca.excludedManifests>org.sonarlint.core.tests/testdata,its/projects</sonar.sca.excludedManifests>
+    <sonar.sca.exclusions>org.sonarlint.core.tests/testdata,its/projects</sonar.sca.exclusions>
 
     <!-- Global properties -->
     <jarsigner.skip>true</jarsigner.skip>


### PR DESCRIPTION
[SLE-1181](https://sonarsource.atlassian.net/browse/SLE-1181)

`sonar.sca.excludedManifests` is deprecated in SQS 2025.3 and is replaced with `sonar.sca.exlusions`. The behavior is exactly the same, this is just a rename to better match other sonar properties.

[SLE-1181]: https://sonarsource.atlassian.net/browse/SLE-1181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ