### PR TITLE
SLE-1185 Handle the failure to open the Welcome page more gracefully

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PlatformUtils.java
@@ -67,8 +67,13 @@ public final class PlatformUtils {
       try {
         // INFO: This information cannot be accessed from any constant, can be seen via "Plug-in Selection Spy"!
         showView("org.eclipse.ui.internal.introview");
-      } catch (PartInitException err) {
-        SonarLintLogger.get().error("Cannot open the 'Welcome' view, make sure Eclipse is properly installed!", err);
+      } catch (Exception err) {
+        // Some Eclipse based applications do not provide the Welcome view at all (which would throw a
+        // PartInitException) and some do not come with the default intro pages we extend and that will be opened by
+        // default by the Welcome view (which will throw a NullPointerException). There might be more cases, and for
+        // that very reason we catch all kinds of exceptions here due to it being out of our scope and just log a debug
+        // message, no need for a confusing error.
+        SonarLintLogger.get().debug("Cannot open the 'Welcome' view", err);
       }
     });
   }


### PR DESCRIPTION
[SLE-1185](https://sonarsource.atlassian.net/browse/SLE-1185)

When using a Eclipse-based application (like specific IDEs) that does not provide the _Welcome_ view at all or not the intro page we extend (what's new / overview page) and that is opened by default by the _Welcome_ view, we should not throw a unhandled runtime exception. In those and other cases, just not open the _Welcome_ view.

Here a screenshot of what it looks like without the change:
<img width="1136" alt="Welcome" src="https://github.com/user-attachments/assets/67ce8f65-95b3-43d5-963b-fc1ff3ba35a5" />

And here are the corresponding Error Log ([Error.log](https://github.com/user-attachments/files/20107307/Error.log)) and the Runtime Error ([Runtime.log](https://github.com/user-attachments/files/20107310/Runtime.log)).

[SLE-1185]: https://sonarsource.atlassian.net/browse/SLE-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ