### PR TITLE
SLE-1212 Reddeer library should correctly work on Eclipse 2025-06+

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
@@ -37,7 +37,6 @@ import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.exception.CoreLayerException;
 import org.eclipse.reddeer.swt.impl.link.DefaultLink;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -409,8 +408,7 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
    */
   @Test
   public void test_NodeJs_from_EclipseWWD() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
 
@@ -634,8 +632,7 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
   }
 
   private static void changeSonarQubeCloudRegionEA(boolean enabled) {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     preferences.enableSonarQubeCloudRegionEA(enabled);

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/AbstractSonarLintTest.java
@@ -42,6 +42,7 @@ import org.eclipse.equinox.security.storage.SecurePreferencesFactory;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.core.exception.CoreLayerException;
 import org.eclipse.reddeer.core.lookup.ShellLookup;
 import org.eclipse.reddeer.eclipse.condition.ConsoleHasText;
 import org.eclipse.reddeer.eclipse.condition.ProjectExists;
@@ -66,6 +67,7 @@ import org.eclipse.reddeer.workbench.impl.editor.AbstractEditor;
 import org.eclipse.reddeer.workbench.impl.editor.Marker;
 import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -80,6 +82,7 @@ import org.sonarlint.eclipse.its.shared.reddeer.conditions.AnalysisReadyAfterUnr
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.FileAssociationsPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.RuleConfigurationPreferences;
 import org.sonarlint.eclipse.its.shared.reddeer.preferences.SonarLintPreferences;
+import org.sonarlint.eclipse.its.shared.reddeer.preferences.WorkbenchPreferenceDialogCustom;
 import org.sonarlint.eclipse.its.shared.reddeer.views.OnTheFlyView;
 import org.sonarlint.eclipse.its.shared.reddeer.views.ReportView;
 import org.sonarlint.eclipse.its.shared.reddeer.views.SonarLintConsole;
@@ -165,8 +168,7 @@ public abstract class AbstractSonarLintTest {
   }
 
   protected static void setFocusOnNewCode(boolean focusOnNewCode) {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     preferences.setFocusOnNewCode(focusOnNewCode);
@@ -174,8 +176,7 @@ public abstract class AbstractSonarLintTest {
   }
 
   protected static void setShowAllMarkers(boolean showAllMarkers) {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     preferences.setShowAllMarkers(showAllMarkers);
@@ -473,5 +474,21 @@ public abstract class AbstractSonarLintTest {
   /** When binding project it will move to unready state before going to ready state again */
   protected static void waitForAnalysisReady(String projectName) {
     new WaitUntil(new AnalysisReadyAfterUnready(projectName), TimePeriod.getCustom(60));
+  }
+
+  // On Eclipse 2025-06, Preferences is labeled "Preferences..." which requires this Custom call
+  public static WorkbenchMenuPreferencesDialog openPreferenceDialog() {
+    try {
+      return openPreferenceDialog(new WorkbenchPreferenceDialogCustom());
+    } catch (CoreLayerException e) {
+      return openPreferenceDialog(new WorkbenchPreferenceDialog());
+    }
+  }
+
+  private static WorkbenchMenuPreferencesDialog openPreferenceDialog(WorkbenchMenuPreferencesDialog preferenceDialog) {
+    if (!preferenceDialog.isOpen()) {
+      preferenceDialog.open();
+    }
+    return preferenceDialog;
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/FileAssociationsPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/FileAssociationsPreferences.java
@@ -24,7 +24,8 @@ import org.eclipse.reddeer.core.matcher.WithLabelMatcher;
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
 import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.reddeer.swt.impl.combo.DefaultCombo;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
+import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
 
 public class FileAssociationsPreferences extends PropertyPage {
   private static final String LABEL = "Open unassociated files with:";
@@ -34,11 +35,7 @@ public class FileAssociationsPreferences extends PropertyPage {
   }
 
   public static FileAssociationsPreferences open() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    if (!preferenceDialog.isOpen()) {
-      preferenceDialog.open();
-    }
-
+    var preferenceDialog = AbstractSonarLintTest.openPreferenceDialog();
     var preferences = new FileAssociationsPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     return preferences;
@@ -63,6 +60,6 @@ public class FileAssociationsPreferences extends PropertyPage {
   }
 
   public void ok() {
-    ((WorkbenchPreferenceDialog) referencedComposite).ok();
+    ((WorkbenchMenuPreferencesDialog) referencedComposite).ok();
   }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/GeneralWorkspaceBuildPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/GeneralWorkspaceBuildPreferences.java
@@ -23,7 +23,8 @@ import org.eclipse.reddeer.core.matcher.WithTextMatcher;
 import org.eclipse.reddeer.core.reference.ReferencedComposite;
 import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.reddeer.swt.impl.button.CheckBox;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
+import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
 
 public class GeneralWorkspaceBuildPreferences extends PropertyPage {
   public GeneralWorkspaceBuildPreferences(ReferencedComposite referencedComposite) {
@@ -45,15 +46,11 @@ public class GeneralWorkspaceBuildPreferences extends PropertyPage {
   }
 
   public void ok() {
-    ((WorkbenchPreferenceDialog) referencedComposite).ok();
+    ((WorkbenchMenuPreferencesDialog) referencedComposite).ok();
   }
 
   public static GeneralWorkspaceBuildPreferences open() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    if (!preferenceDialog.isOpen()) {
-      preferenceDialog.open();
-    }
-
+    var preferenceDialog = AbstractSonarLintTest.openPreferenceDialog();
     var generalWorkspaceBuildPreferences = new GeneralWorkspaceBuildPreferences(preferenceDialog);
     preferenceDialog.select(generalWorkspaceBuildPreferences);
     return generalWorkspaceBuildPreferences;

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/ReleaseNotesPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/ReleaseNotesPreferences.java
@@ -26,15 +26,16 @@ import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.reddeer.swt.api.Browser;
 import org.eclipse.reddeer.swt.condition.PageIsLoaded;
 import org.eclipse.reddeer.swt.impl.browser.InternalBrowser;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
+import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
 
 public class ReleaseNotesPreferences extends PropertyPage {
-  public ReleaseNotesPreferences(WorkbenchPreferenceDialog preferenceDialog) {
+  public ReleaseNotesPreferences(WorkbenchMenuPreferencesDialog preferenceDialog) {
     super(preferenceDialog, "SonarQube", "Release Notes");
   }
 
   public void cancel() {
-    ((WorkbenchPreferenceDialog) referencedComposite).cancel();
+    ((WorkbenchMenuPreferencesDialog) referencedComposite).cancel();
   }
 
   public Browser getFirstBrowser() {
@@ -50,11 +51,7 @@ public class ReleaseNotesPreferences extends PropertyPage {
   }
 
   public static ReleaseNotesPreferences open() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    if (!preferenceDialog.isOpen()) {
-      preferenceDialog.open();
-    }
-
+    var preferenceDialog = AbstractSonarLintTest.openPreferenceDialog();
     var releaseNotesPreferences = new ReleaseNotesPreferences(preferenceDialog);
     preferenceDialog.select(releaseNotesPreferences);
     return releaseNotesPreferences;

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/RuleConfigurationPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/RuleConfigurationPreferences.java
@@ -29,11 +29,12 @@ import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.swt.impl.spinner.DefaultSpinner;
 import org.eclipse.reddeer.swt.impl.text.DefaultText;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTree;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
+import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
 
 public class RuleConfigurationPreferences extends PropertyPage {
 
-  public RuleConfigurationPreferences(WorkbenchPreferenceDialog preferenceDialog) {
+  public RuleConfigurationPreferences(WorkbenchMenuPreferencesDialog preferenceDialog) {
     super(preferenceDialog, "SonarQube", "Rules Configuration");
   }
 
@@ -69,19 +70,15 @@ public class RuleConfigurationPreferences extends PropertyPage {
   }
 
   public void cancel() {
-    ((WorkbenchPreferenceDialog) referencedComposite).cancel();
+    ((WorkbenchMenuPreferencesDialog) referencedComposite).cancel();
   }
 
   public void ok() {
-    ((WorkbenchPreferenceDialog) referencedComposite).ok();
+    ((WorkbenchMenuPreferencesDialog) referencedComposite).ok();
   }
 
   public static RuleConfigurationPreferences open() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    if (!preferenceDialog.isOpen()) {
-      preferenceDialog.open();
-    }
-
+    var preferenceDialog = AbstractSonarLintTest.openPreferenceDialog();
     var ruleConfigurationPreferences = new RuleConfigurationPreferences(preferenceDialog);
     preferenceDialog.select(ruleConfigurationPreferences);
     return ruleConfigurationPreferences;

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/WorkbenchPreferenceDialogCustom.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/WorkbenchPreferenceDialogCustom.java
@@ -1,0 +1,71 @@
+/*
+ * SonarLint for Eclipse ITs
+ * Copyright (C) 2009-2025 SonarSource SA
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.its.shared.reddeer.preferences;
+
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.common.matcher.RegexMatcher;
+import org.eclipse.reddeer.common.platform.RunningPlatform;
+import org.eclipse.reddeer.common.util.Display;
+import org.eclipse.reddeer.core.matcher.WithTextMatcher;
+import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
+import org.eclipse.reddeer.workbench.workbenchmenu.WorkbenchMenuPreferencesDialog;
+import org.eclipse.ui.dialogs.PreferencesUtil;
+
+public class WorkbenchPreferenceDialogCustom extends WorkbenchMenuPreferencesDialog {
+
+  private final Logger log = Logger.getLogger(WorkbenchPreferenceDialogCustom.class);
+
+  public WorkbenchPreferenceDialogCustom() {
+    super(new WithTextMatcher(new RegexMatcher("Preferences.*")), "Window", "Preferences...");
+  }
+
+  @Override
+  public void open() {
+    if (!isOpen()) {
+      if (RunningPlatform.isOSX()) {
+        log.info("Open Preferences directly on Mac OSX");
+        new WorkbenchShell();
+        handleMacMenu();
+        setShell(new DefaultShell(matcher));
+      } else {
+        super.open();
+      }
+    }
+  }
+
+  private void handleMacMenu() {
+    Display.asyncExec(new Runnable() {
+      @Override
+      public void run() {
+        var dialog = PreferencesUtil.createPreferenceDialogOn(null,
+          null, null, null);
+        dialog.open();
+      }
+    });
+    Display.syncExec(new Runnable() {
+      @Override
+      public void run() {
+        // do nothing just process UI events
+      }
+    });
+  }
+
+}

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/AnalyzerPropertiesTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/AnalyzerPropertiesTest.java
@@ -21,7 +21,6 @@ package org.sonarlint.eclipse.its.standalone;
 
 import org.eclipse.reddeer.eclipse.ui.dialogs.PropertyDialog;
 import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.junit.After;
 import org.junit.Test;
 import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
@@ -34,9 +33,7 @@ import static org.assertj.core.api.Assertions.tuple;
 public class AnalyzerPropertiesTest extends AbstractSonarLintTest {
   @After
   public void clearGlobalAnalyzerProperties() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
-
+    var preferenceDialog = openPreferenceDialog();
     var analyzerPropertiesPreferences = new AnalyzerPropertiesPreferences(preferenceDialog);
     preferenceDialog.select(analyzerPropertiesPreferences);
 
@@ -59,9 +56,7 @@ public class AnalyzerPropertiesTest extends AbstractSonarLintTest {
       tuple("Replace this use of System.out by a logger.", "Hello.java", "few seconds ago"));
 
     // i) Change global properties
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
-
+    var preferenceDialog = openPreferenceDialog();
     var analyzerPropertiesPreferences = new AnalyzerPropertiesPreferences(preferenceDialog);
     preferenceDialog.select(analyzerPropertiesPreferences);
 

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/FileExclusionsTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/FileExclusionsTest.java
@@ -28,7 +28,6 @@ import org.eclipse.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.eclipse.reddeer.swt.impl.button.OkButton;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.junit.After;
 import org.junit.Test;
 import org.sonarlint.eclipse.its.shared.AbstractSonarLintTest;
@@ -98,9 +97,7 @@ public class FileExclusionsTest extends AbstractSonarLintTest {
 
   @Test
   public void should_add_new_entry() {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
-
+    var preferenceDialog = openPreferenceDialog();
     var fileExclusionsPreferences = new FileExclusionsPreferences(preferenceDialog);
     preferenceDialog.select(fileExclusionsPreferences);
 

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/QuickFixesTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/QuickFixesTest.java
@@ -49,7 +49,6 @@ import org.eclipse.reddeer.workbench.condition.TextEditorContainsText;
 import org.eclipse.reddeer.workbench.exception.WorkbenchLayerException;
 import org.eclipse.reddeer.workbench.impl.editor.DefaultEditor;
 import org.eclipse.reddeer.workbench.impl.editor.TextEditor;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -227,8 +226,7 @@ public class QuickFixesTest extends AbstractSonarLintTest {
   }
 
   private static void changeSonarLintMarkerSeverity(MarkerSeverity severity) {
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     preferences.setMarkersSeverity(severity);

--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
@@ -45,7 +45,6 @@ import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
 import org.eclipse.reddeer.workbench.impl.editor.DefaultEditor;
 import org.eclipse.reddeer.workbench.impl.editor.TextEditor;
-import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -332,8 +331,7 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
     new JavaPerspective().open();
     var rootProject = importExistingProjectIntoWorkspace("java/java-junit", "java-junit");
 
-    var preferenceDialog = new WorkbenchPreferenceDialog();
-    preferenceDialog.open();
+    var preferenceDialog = openPreferenceDialog();
     var preferences = new SonarLintPreferences(preferenceDialog);
     preferenceDialog.select(preferences);
     preferences.setTestFileRegularExpressions("**/*TestUtil*");


### PR DESCRIPTION
[SLE-1212](https://sonarsource.atlassian.net/browse/SLE-1212)

Starting from Eclipse 2025-06, tests are failing because Reddeer is looking for the menu “Preferences” while it’s now named “Preferences…”.

As a first workaround, we can create a new class with the fixed regex. We should take care of falling back to the previous label because this component is used across all the tests.

In the future, we should probably patch our Reddeer fork.

[SLE-1212]: https://sonarsource.atlassian.net/browse/SLE-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ