### PR TITLE
Avoid useless computation of element.toString() if not used in SonarLintUtils.adapt

### DIFF
--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/utils/SonarLintUtils.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.core.resources.IProject;
@@ -208,19 +209,29 @@ public class SonarLintUtils {
    *  succeed!
    */
   @Nullable
+  public static <T> T adapt(@Nullable Object sourceObject, Class<T> adapter, Supplier<String> trace) {
+      if (sourceObject == null) {
+          SonarLintLogger.get().traceIdeMessage(trace.get());
+          return null;
+      }
+
+      var adapted = Adapters.adapt(sourceObject, adapter);
+      if (adapted == null) {
+          SonarLintLogger.get().traceIdeMessage(trace.get() + " -> '" + sourceObject.toString() + "' could not be adapted to '"
+                  + adapter.getCanonicalName() + "'");
+      }
+
+      return adapted;
+  }
+
+  /**
+   *  Wrapper around {@link org.eclipse.core.runtime.Adapters#adapt(Object, Class)} in order to log debug information
+   *  which we then can use when debugging / investigating issues. Tracing is used for checking when this does not
+   *  succeed!
+   */
+  @Nullable
   public static <T> T adapt(@Nullable Object sourceObject, Class<T> adapter, String trace) {
-    if (sourceObject == null) {
-      SonarLintLogger.get().traceIdeMessage(trace);
-      return null;
-    }
-
-    var adapted = Adapters.adapt(sourceObject, adapter);
-    if (adapted == null) {
-      SonarLintLogger.get().traceIdeMessage(trace + " -> '" + sourceObject.toString() + "' could not be adapted to '"
-        + adapter.getCanonicalName() + "'");
-    }
-
-    return adapted;
+      return adapt(sourceObject, adapter, () -> trace);
   }
 
   public static ISonarLintProject resolveProject(String configScopeId) throws ConfigScopeNotFoundException {

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintProjectDecorator.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/SonarLintProjectDecorator.java
@@ -38,7 +38,7 @@ public class SonarLintProjectDecorator implements ILightweightLabelDecorator {
   @Override
   public void decorate(Object element, IDecoration decoration) {
     var project = SonarLintUtils.adapt(element, ISonarLintProject.class,
-      "[SonarLintProjectDecorator#decorate] Try get project of object '" + element + "'");
+              () -> "[SonarLintProjectDecorator#decorate] Try get project of object '" + element + "'");
     if (project != null && project.isOpen()) {
       var config = SonarLintCorePlugin.loadConfig(project);
       if (!config.isAutoEnabled()) {


### PR DESCRIPTION
Avoid useless computation of element.toString() if not used in SonarLintUtils.adapt

<img width="1670" height="1002" alt="image" src="https://github.com/user-attachments/assets/75413649-72d5-480a-b20f-1a71839d5a7f" />

Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-eclipse/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
