### PR TITLE
SLE-1475 SLE-1477 SLE-1480 SLE-1484 SLE-1485 SLE-1487 SLE-1488 SLE-1490 SLE-1492 SLE-1500 12.3 analyzer updates

### DIFF
--- a/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
+++ b/its/org.sonarlint.eclipse.its.standalone/src/org/sonarlint/eclipse/its/standalone/StandaloneAnalysisTest.java
@@ -399,7 +399,7 @@ public class StandaloneAnalysisTest extends AbstractSonarLintTest {
 
     var defaultEditor = new DefaultEditor();
     waitForMarkers(defaultEditor,
-      tuple("Unexpected double-slash CSS comment", 1));
+      tuple("Invalid double-slash CSS comment", 1));
   }
 
   @Test

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -117,7 +117,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.text</groupId>
                   <artifactId>sonar-text-plugin</artifactId>
-                  <version>2.42.0.10784</version>
+                  <version>2.43.0.11106</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -160,7 +160,7 @@
                     <artifactItem>
                       <groupId>com.sonarsource.cpp</groupId>
                       <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.81.0.99236</version>
+                      <version>6.81.1.99296</version>
                       <type>jar</type>
                     </artifactItem>
                   </artifactItems>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -111,7 +111,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.xml</groupId>
                   <artifactId>sonar-xml-plugin</artifactId>
-                  <version>2.16.0.7616</version>
+                  <version>2.17.0.7895</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -160,7 +160,7 @@
                     <artifactItem>
                       <groupId>com.sonarsource.cpp</groupId>
                       <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.80.0.98490</version>
+                      <version>6.81.0.99236</version>
                       <type>jar</type>
                     </artifactItem>
                   </artifactItems>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -87,7 +87,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>12.4.0.40770</version>
+                  <version>12.5.0.41048</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -75,7 +75,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.java</groupId>
                   <artifactId>sonar-java-plugin</artifactId>
-                  <version>8.28.0.43176</version>
+                  <version>8.29.0.43460</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -105,7 +105,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.html</groupId>
                   <artifactId>sonar-html-plugin</artifactId>
-                  <version>3.25.0.7473</version>
+                  <version>3.26.0.7600</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -99,7 +99,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.21.0.32726</version>
+                  <version>5.22.0.33216</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -87,7 +87,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>12.3.0.39932</version>
+                  <version>12.4.0.40770</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -93,7 +93,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.php</groupId>
                   <artifactId>sonar-php-plugin</artifactId>
-                  <version>3.56.0.15870</version>
+                  <version>3.57.0.15976</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -25,6 +25,7 @@
     </p>
     <ul>
         <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.26.0.7600">3.26</a></li>
+        <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.29.0.43460">8.29</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -26,6 +26,7 @@
     <ul>
         <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.26.0.7600">3.26</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.29.0.43460">8.29</a></li>
+        <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -29,7 +29,7 @@
         <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
         <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
-        <li>Update CFamily analyzer -> 6.81.0</li>
+        <li>Update CFamily analyzer -> 6.81.1</li>
         <li>Update PHP analyzer -> <a href="https://github.com/SonarSource/sonar-php/releases/tag/3.57.0.15976">3.57</a></li>
         <li>Update XML analyzer -> <a href="https://github.com/SonarSource/sonar-xml/releases/tag/2.17.0.7895">2.17</a></li>
     </ul>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -29,6 +29,7 @@
         <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
         <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
+        <li>Update CFamily analyzer -> 6.81.0</li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -30,6 +30,7 @@
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
         <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
         <li>Update CFamily analyzer -> 6.81.0</li>
+        <li>Update PHP analyzer -> <a href="https://github.com/SonarSource/sonar-php/releases/tag/3.57.0.15976">3.57</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -27,7 +27,7 @@
         <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.26.0.7600">3.26</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.29.0.43460">8.29</a></li>
         <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
-        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
+        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.5.0.41048">12.5</a></li>
         <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
         <li>Update CFamily analyzer -> 6.81.1</li>
         <li>Update PHP analyzer -> <a href="https://github.com/SonarSource/sonar-php/releases/tag/3.57.0.15976">3.57</a></li>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -27,6 +27,7 @@
         <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.26.0.7600">3.26</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.29.0.43460">8.29</a></li>
         <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
+        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -31,6 +31,7 @@
         <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
         <li>Update CFamily analyzer -> 6.81.0</li>
         <li>Update PHP analyzer -> <a href="https://github.com/SonarSource/sonar-php/releases/tag/3.57.0.15976">3.57</a></li>
+        <li>Update XML analyzer -> <a href="https://github.com/SonarSource/sonar-xml/releases/tag/2.17.0.7895">2.17</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -19,9 +19,20 @@
 -->
 
 <div>
-    <h1>12.2</h1>
+    <h1>12.3</h1>
     <p>
         See the <a href="https://github.com/SonarSource/sonarlint-eclipse/releases">GitHub Release page</a>
+    </p>
+    <ul>
+        <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.26.0.7600">3.26</a></li>
+    </ul>
+</div>
+
+
+<div>
+    <h2>12.2</h2>
+    <p>
+        See the <a href="https://github.com/SonarSource/sonarlint-eclipse/releases/tag/12.2.1.84686">GitHub Release page</a>
     </p>
     <ul>
         <li>Update Java analyzer -> 8.28</li>
@@ -40,22 +51,6 @@
     <ul>
         <li>Update Python analyzer -> 5.21</li>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.3.0.39932">12.3</a></li>
-    </ul>
-</div>
-
-<div>
-    <h2>12.0</h2>
-    <p>
-        See the <a href="https://github.com/SonarSource/sonarlint-eclipse/releases/tag/12.0.0.84623">GitHub Release page</a>
-    </p>
-    <ul>
-        <li>Require Java 21 to run the backend</li>
-        <li>Timeout if the backend is not responsive</li>
-        <li>Update CFamily analyzer -> 6.79</li>
-        <li>Update HTML analyzer -> <a href="https://github.com/SonarSource/sonar-html/releases/tag/3.25.0.7473">3.25</a></li>
-        <li>Update Text and Secrets analyzer -> 2.42</li>
-        <li>Update Python analyzer -> 5.20</li>
-        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.2.0.39785">12.2</a></li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -28,6 +28,7 @@
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.29.0.43460">8.29</a></li>
         <li>Update Text and Secrets analyzer -> <a href="https://github.com/SonarSource/sonar-text/releases/tag/2.43.0.11106">2.43</a></li>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/12.4.0.40770">12.4</a></li>
+        <li>Update Python analyzer -> <a href="https://github.com/SonarSource/sonar-python/releases/tag/5.22.0.33216">5.22</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
Analyzer updates for the 12.3 release.

- SLE-1475 Update html to 3.26.0.7600
- SLE-1477 Update java to 8.29.0.43460
- SLE-1480 Update text to 2.43.0.11106
- SLE-1484 Update javascript to 12.4.0.40770
- SLE-1485 Update SonarPython analyzer to 5.22.0.33216
- SLE-1487 Update CFamily analyzer to 6.81.0.99236
- SLE-1488 Update php to 3.57.0.15976
- SLE-1490 Update xml to 2.17.0.7895
- SLE-1492 Update CFamily analyzer to 6.81.1.99296
- SLE-1500 Update javascript to 12.5.0.41048

Release notes restructured: new 12.3 H1 block, 12.2 demoted to H2 with link to tag 12.2.1.84686, oldest (12.0) block removed to keep 3 versions max.