### PR TITLE
SLE-1502 Do not trigger Renovate on its' projects

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:ide-xp-team"
+  ],
+  "ignorePaths": [
+    "its/projects/**"
   ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate configuration:**
  - Added `ignorePaths` rule to exclude `its/projects/**` from Renovate automation

<sub>This will update automatically on new commits.</sub>