### PR TITLE
PREQ-6517 Retry + debug jarsigner KeyLocker signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,12 @@
               <providerArg>${env.SMTOOLS_PATH}/pkcs11properties.cfg</providerArg>
               <tsa>http://timestamp.digicert.com</tsa>
               <verbose>true</verbose>
+              <!-- PREQ-6517: surface the underlying SunPKCS11/KeyLocker error
+                   (e.g. HTTP 429 rate-limit) behind the opaque
+                   "keystore load: load failed" message -->
+              <arguments>
+                <argument>-J-Djava.security.debug=sunpkcs11</argument>
+              </arguments>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,11 @@
               <providerArg>${env.SMTOOLS_PATH}/pkcs11properties.cfg</providerArg>
               <tsa>http://timestamp.digicert.com</tsa>
               <verbose>true</verbose>
+              <!-- PREQ-6517: the network-backed DigiCert KeyLocker PKCS11 keystore
+                   intermittently fails to load ("keystore load: load failed"),
+                   suspected HTTP 429 rate-limiting. Retry with exponential backoff. -->
+              <maxTries>3</maxTries>
+              <maxRetryDelaySeconds>15</maxRetryDelaySeconds>
               <!-- PREQ-6517: surface the underlying SunPKCS11/KeyLocker error
                    (e.g. HTTP 429 rate-limit) behind the opaque
                    "keystore load: load failed" message -->


### PR DESCRIPTION
## Summary
Hardens the Eclipse update-site signing step against intermittent DigiCert KeyLocker PKCS11 failures, and makes the failure mode self-diagnosing. Both changes are scoped to the `sign` profile in `pom.xml` (release/`master` signing builds only).

1. **Retry with backoff** — `maxTries=3`, `maxRetryDelaySeconds=15` (first-party `maven-jarsigner-plugin` params, since 3.1.0, intended for network-based PKCS11/TSA signing). A single transient keystore-load failure no longer fails the whole build.
2. **Diagnostics** — `-J-Djava.security.debug=sunpkcs11` so the underlying PKCS11/HTTP error (e.g. `429 request_limit_exceeded`) is printed instead of the opaque `keystore load: load failed`.

## Why
The `master` signing step intermittently fails ([PREQ-6517](https://sonarsource.atlassian.net/browse/PREQ-6517), e.g. [run 27623477292](https://github.com/SonarSource/sonarlint-eclipse/actions/runs/27623477292/attempts/1)) with:
```
jarsigner error: java.lang.RuntimeException: keystore load: load failed
```
Investigation ruled out the usual culprits:
- **Certificate** valid (13 Oct 2025 → 15 Nov 2027).
- **Signature quota** not exhausted (38,323 / 44,000 used; 5,677 left).
- **DigiCert KeyLocker** status Operational; tooling/volume unchanged vs the last green build (June 5 signed 51 jars fine).

The failure is intermittent with a **variable failure point** (45 jars signed then fail on attempt 1, 32 on the re-run), which points to a transient KeyLocker error — most likely **HTTP 429 rate-limiting** on the shared signing API key. `maxTries` fixes the symptom now; the debug flag confirms the root cause on the next occurrence.

## Scope / risk
- Only the `sign` profile (release/`master`); no effect on PR/dev builds.
- Retry uses exponential backoff; DigiCert's rolling rate-limit window clears in seconds.
- The debug flag is additive logging and can be removed once root cause is confirmed.

## Test plan
- [ ] Trigger a `master` signing build; confirm it completes (retry absorbs any transient failure).
- [ ] Confirm jarsigner emits `sunpkcs11:` debug lines.
- [ ] On any retried/failed attempt, capture the underlying PKCS11/HTTP status (expecting `429 request_limit_exceeded` if rate-limiting).

[PREQ-6517]: https://sonarsource.atlassian.net/browse/PREQ-6517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ