### PR TITLE
SLE-1533 Remove client-side CFamily embedding

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5,6 +5,6 @@ mailto:info AT sonarsource DOT com
 
 This program is distributed with SonarQube analyzers that are subject to specific license terms.
 
-The sonar-cfamily-plugin is a SonarQube analyzer published under the following proprietary license: SonarSource Sàrl  grants you a non-transferable, non-sublicensable, limited license to use the aforementioned plugins solely as part of this program. Any use, reproduction, distribution, or modification of the plugins outside the scope of this program is strictly prohibited.
+The sonar-cfamily-plugin is a SonarQube analyzer published under the following proprietary license: SonarSource Sàrl grants you a non-transferable, non-sublicensable, limited license to use the aforementioned plugins solely as part of this program. Any use, reproduction, distribution, or modification of the plugins outside the scope of this program is strictly prohibited.
 
 All of the other analyzers distributed with this program are published under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl. For more details see https://sonarsource.com/license/ssal/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Normally, m2e will automatically suggest to install missing connectors (Tycho co
 missing lifecycle mappings. This can all be done later.
 
 1. Run `mvn clean verify -DskipTests` on the command line to fetch artifacts referenced in the parent pom
- - for forks use `-Dskip-sonarsource-repo` as the reference to the CFamily analyzer is not available on Maven Central
 2. In Eclipse, import the project root as a Maven project
 3. In Eclipse, import the project root of the ITs as a Maven project and add them to the main project
 4. Open `target-platforms/dev.target` with the target platform editor
@@ -69,8 +68,6 @@ In Eclipse:
 With Maven:
 
     mvn clean verify
-
- - for forks use `-Dskip-sonarsource-repo` as the reference to the CFamily analyzer is not available on Maven Central
 
 Running ITs
 -----------

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -130,49 +130,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <!--
-    Since the CFamily plug-in is not uploaded to Maven Central as it is not Open Source, this is not vailable to forks.
-    Forks must use "-Dskip-sonarsource-repo" when building the plug-in!
-  -->
-  <profiles>
-    <profile>
-      <id>cfamily-analyzer</id>
-      <activation>
-        <property>
-          <name>!skip-sonarsource-repo</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-cfamily-analyzer</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>copy</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>com.sonarsource.cpp</groupId>
-                      <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.81.1.99296</version>
-                      <type>jar</type>
-                    </artifactItem>
-                  </artifactItems>
-                  <outputDirectory>${project.basedir}/plugins</outputDirectory>
-                  <overWriteReleases>false</overWriteReleases>
-                  <overWriteSnapshots>true</overWriteSnapshots>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/PluginPathHelper.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/PluginPathHelper.java
@@ -79,11 +79,6 @@ public class PluginPathHelper {
   }
 
   @Nullable
-  public static Path findEmbeddedCFamilyPlugin() {
-    return findEmbeddedPlugin("sonar-cfamily-plugin-*.jar", "Found CFamily plugin: ");
-  }
-
-  @Nullable
   private static Path findEmbeddedPlugin(String pluginNamePattern, String logPrefix) {
     var pluginEntriesEnum = SonarLintCorePlugin.getInstance().getBundle()
       .findEntries("/plugins", pluginNamePattern, false);

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/backend/SonarLintBackendService.java
@@ -187,7 +187,6 @@ public class SonarLintBackendService {
           embeddedPlugins.put("web", requireNonNull(PluginPathHelper.findEmbeddedHtmlPlugin(), "HTML plugin not found"));
           embeddedPlugins.put("xml", requireNonNull(PluginPathHelper.findEmbeddedXmlPlugin(), "XML plugin not found"));
           embeddedPlugins.put("text", requireNonNull(PluginPathHelper.findEmbeddedSecretsPlugin(), "Secrets plugin not found"));
-          embeddedPlugins.put("cpp", requireNonNull(PluginPathHelper.findEmbeddedCFamilyPlugin(), "CFamily plugin not found"));
 
           var sqConnections = ConnectionSynchronizer.buildSqConnectionDtos();
           var scConnections = ConnectionSynchronizer.buildScConnectionDtos();


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency and configuration changes:**
  - Removed `sonar-cfamily-plugin` dependency from `org.sonarlint.eclipse.core/pom.xml`.
  - Cleaned up `PluginPathHelper.java` and `SonarLintBackendService.java` to remove CFamily-specific path handling.
- **Documentation updates:**
  - Removed reference to CFamily from `README.md` and updated `NOTICE.txt` accordingly.

<sub>This will update automatically on new commits.</sub>