### PR TITLE
SLE-1569 Update 'sonarlint-core' to 11.7.0.86025

### DIFF
--- a/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.core/META-INF/MANIFEST.MF
@@ -43,6 +43,6 @@ Require-Bundle: org.eclipse.equinox.security;resolution:=optional,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.text,
  org.eclipse.wildwebdeveloper.embedder.node;resolution:=optional,
- org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[11.6.0,11.7.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[11.7.0,11.8.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
+++ b/org.sonarlint.eclipse.ui/META-INF/MANIFEST.MF
@@ -27,7 +27,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.text,
  org.eclipse.compare,
  org.eclipse.core.expressions,
- org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[11.6.0,11.7.0)"
+ org.sonarsource.sonarlint.core.sonarlint-java-client-osgi;bundle-version="[11.7.0,11.8.0)"
 Export-Package: org.sonarlint.eclipse.ui.internal;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.backend;x-friends:="org.sonarlint.eclipse.core.tests",
  org.sonarlint.eclipse.ui.internal.notifications;x-friends:="org.sonarlint.eclipse.core.tests",

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <tycho.version>4.0.12</tycho.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>11.6.0.85952</sloop.version>
+    <sloop.version>11.7.0.86025</sloop.version>
 
     <!-- SonarQube analysis -->
     <sonar.java.source>11</sonar.java.source>

--- a/target-platforms/commons-build.target
+++ b/target-platforms/commons-build.target
@@ -12,7 +12,7 @@
         <dependency>
           <groupId>org.sonarsource.sonarlint.core</groupId>
           <artifactId>sonarlint-java-client-osgi</artifactId>
-          <version>11.6.0.85952</version>
+          <version>11.7.0.86025</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
    - Updated `sonarlint-java-client-osgi` version to `11.7.0.86025` in `commons-build.target` and `pom.xml`.
    - Updated bundle version requirements for `org.sonarsource.sonarlint.core.sonarlint-java-client-osgi` to `[11.7.0,11.8.0)` in `core` and `ui` manifest files.

<sub>This will update automatically on new commits.</sub>