### PR TITLE
SLE-1571 Change the slack channel for freeze/unfreeze notifications

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -37,7 +37,7 @@ jobs:
       project-name: "SonarLint for Eclipse"
       short-description: ${{ inputs.short-description }}
       branch: ${{ inputs.branch }}
-      slack-channel: "C02E6L5C01H"
+      slack-channel: "C06M11XJHCN" #squad-ide-eclipse-bots
       is-test-run: ${{ inputs.dry-run }}
       new-version: ${{ inputs.new-version }}
 


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
    - Updated `slack-channel` ID in `full-release.yml` to redirect freeze/unfreeze notifications to `#squad-ide-eclipse-bots`.

<sub>This will update automatically on new commits.</sub>