### PR TITLE
SLE-1583 Remove the SQC region selection checkbox

### DIFF
--- a/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
+++ b/its/org.sonarlint.eclipse.its.connected.sc/src/org/sonarlint/eclipse/its/connected/sc/SonarCloudConnectedModeTest.java
@@ -34,10 +34,8 @@ import org.assertj.core.groups.Tuple;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
-import org.eclipse.reddeer.core.exception.CoreLayerException;
 import org.eclipse.reddeer.swt.impl.link.DefaultLink;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
@@ -72,7 +70,6 @@ import org.sonarqube.ws.client.usertokens.RevokeRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertThrows;
 
 public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
   private static final String TIMESTAMP = Long.toString(Instant.now().toEpochMilli());
@@ -130,11 +127,6 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
       .revoke(new RevokeRequest().setName(TOKEN_NAME));
   }
 
-  @After
-  public void disableSonarQubeCloudRegionEA() {
-    changeSonarQubeCloudRegionEA(false);
-  }
-
   @Before
   public void cleanBindings() {
     var bindingsView = new BindingsView();
@@ -148,20 +140,11 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
     wizard.open();
     var serverTypePage = new ServerConnectionWizard.ServerTypePage(wizard);
 
-    // i) Try to select EU/US that is not yet available (we cannot query the UI text but just check for
     serverTypePage.selectSonarCloud();
-    assertThrows(CoreLayerException.class, serverTypePage::selectSonarQubeCloudEuRegion);
-    assertThrows(CoreLayerException.class, serverTypePage::selectSonarQubeCloudUsRegion);
-    wizard.cancel();
+    assertThat(serverTypePage.isSonarQubeCloudEuRegionSelected()).isTrue();
 
-    // ii) Enable SonarQube Cloud Region
-    changeSonarQubeCloudRegionEA(true);
-    wizard = new ServerConnectionWizard();
-    wizard.open();
-    serverTypePage = new ServerConnectionWizard.ServerTypePage(wizard);
-
-    // iii) Check that region selectors are available, disabled when selecting SonarQube Server and
-    // then select the region based on the environment property.
+    // Check that region selectors are disabled when selecting SonarQube Server, then select the region
+    // based on the environment property.
     serverTypePage.selectSonarQube();
     assertThat(serverTypePage.isSonarQubeCloudEuRegionEnabled()).isFalse();
     assertThat(serverTypePage.isSonarQubeCloudUsRegionEnabled()).isFalse();
@@ -633,11 +616,4 @@ public class SonarCloudConnectedModeTest extends AbstractSonarLintTest {
     projectBindingWizard.finish();
   }
 
-  private static void changeSonarQubeCloudRegionEA(boolean enabled) {
-    var preferenceDialog = openPreferenceDialog();
-    var preferences = new SonarLintPreferences(preferenceDialog);
-    preferenceDialog.select(preferences);
-    preferences.enableSonarQubeCloudRegionEA(enabled);
-    preferenceDialog.ok();
-  }
 }

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/SonarLintPreferences.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/preferences/SonarLintPreferences.java
@@ -54,10 +54,6 @@ public class SonarLintPreferences extends PropertyPage {
     new CheckBox(this, new WithTextMatcher("Show SonarQube markers only for new code")).toggle(focusOnNewCode);
   }
 
-  public void enableSonarQubeCloudRegionEA(boolean enableEarlyAccess) {
-    new CheckBox(this, new WithTextMatcher("Show region selection for SonarQube Cloud")).toggle(enableEarlyAccess);
-  }
-
   public enum MarkerSeverity {
     ERROR("Error"), WARNING("Warning"), INFO("Info");
 

--- a/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/wizards/ServerConnectionWizard.java
+++ b/its/org.sonarlint.eclipse.its.shared/src/org/sonarlint/eclipse/its/shared/reddeer/wizards/ServerConnectionWizard.java
@@ -67,6 +67,10 @@ public class ServerConnectionWizard extends NewMenuWizard {
       return getSonarQubeCloudEuRegionRB().isEnabled();
     }
 
+    public boolean isSonarQubeCloudEuRegionSelected() {
+      return getSonarQubeCloudEuRegionRB().isSelected();
+    }
+
     public boolean isSonarQubeCloudUsRegionEnabled() {
       return getSonarQubeCloudUsRegionRB().isEnabled();
     }

--- a/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
+++ b/org.sonarlint.eclipse.core/src/org/sonarlint/eclipse/core/internal/preferences/SonarLintGlobalConfiguration.java
@@ -77,7 +77,6 @@ public class SonarLintGlobalConfiguration {
   public static final int PREF_MARKER_SEVERITY_DEFAULT = IMarker.SEVERITY_INFO;
   public static final String PREF_ISSUE_INCLUDE_RESOLVED = "allIssuesIncludingResolved"; //$NON-NLS-1$
   public static final String PREF_ISSUE_ONLY_NEW_CODE = "onlyIssuesNewCode"; //$NON-NLS-1$
-  public static final String PREF_SHOW_REGION_SELECTOR = "showRegionSelector"; //$NON-NLS-1S
   public static final String PREF_EXTRA_ARGS = "extraArgs"; //$NON-NLS-1$
   public static final String PREF_FILE_EXCLUSIONS = "fileExclusions"; //$NON-NLS-1$
   public static final String PREF_RULES_CONFIG = "rulesConfig"; //$NON-NLS-1$
@@ -176,10 +175,6 @@ public class SonarLintGlobalConfiguration {
     return Platform.getPreferencesService().getInt(SonarLintCorePlugin.UI_PLUGIN_ID, PREF_MARKER_SEVERITY, PREF_MARKER_SEVERITY_DEFAULT, null);
   }
   
-  public static boolean shouldShowRegionSelection() {
-    return getPreferenceBoolean(PREF_SHOW_REGION_SELECTOR);
-  }
-
   public static List<SonarLintProperty> getExtraPropertiesForLocalAnalysis(ISonarLintProject project) {
     var props = new ArrayList<SonarLintProperty>();
     // First add all global properties

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/BindingsViewLabelProvider.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/BindingsViewLabelProvider.java
@@ -19,7 +19,6 @@
  */
 package org.sonarlint.eclipse.ui.internal.binding;
 
-import java.util.stream.Collectors;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.Image;
@@ -28,7 +27,6 @@ import org.eclipse.ui.ide.IDE.SharedImages;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
 import org.sonarlint.eclipse.core.internal.engine.connected.ConnectionFacade;
 import org.sonarlint.eclipse.core.internal.engine.connected.SonarProject;
-import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.utils.StringUtils;
 import org.sonarlint.eclipse.core.resource.ISonarLintProject;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
@@ -88,10 +86,9 @@ public class BindingsViewLabelProvider extends BaseCellLabelProvider {
   
   private static String getRegionPrefix(ConnectionFacade connection) {
     var allConnections = SonarLintCorePlugin.getConnectionManager().getConnections();
-    var sonarQubeCloudConnectionCount = allConnections.stream().filter(c -> c.isSonarCloud()).collect(Collectors.toList()).size();
+    var sonarQubeCloudConnectionCount = allConnections.stream().filter(ConnectionFacade::isSonarCloud).count();
     var regionLabel = StringUtils.isNotBlank(connection.getSonarCloudRegion()) ? connection.getSonarCloudRegion() : "EU";
-    return SonarLintGlobalConfiguration.shouldShowRegionSelection() &&
-      connection.isSonarCloud() &&
+    return connection.isSonarCloud() &&
       sonarQubeCloudConnectionCount > 1 ? String.format("[%s] ", regionLabel) : "";
   }
 

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ConnectionTypeWizardPage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/binding/wizard/connection/ConnectionTypeWizardPage.java
@@ -32,7 +32,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
-import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.core.internal.telemetry.LinkTelemetry;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
@@ -90,55 +89,53 @@ public class ConnectionTypeWizardPage extends WizardPage {
     var dataBindingContext = new DataBindingContext();
     dataBindingContext.bindValue(connectionTypeSelectObservable, PojoPropertiesCompat.value(ServerConnectionModel.PROPERTY_CONNECTION_TYPE).observe(model));
     
-    if (SonarLintGlobalConfiguration.shouldShowRegionSelection()) {
-      var sonarQubeCloudRegionRadioButtonGroup = new Composite(radioButtonGroupContainer, SWT.NONE);
-      var sonarQubeCloudRegionRadioButtonGroupLayout = new GridLayout();
-      sonarQubeCloudRegionRadioButtonGroupLayout.numColumns = 1;
-      sonarQubeCloudRegionRadioButtonGroup.setLayout(sonarQubeCloudRegionRadioButtonGroupLayout);
-      sonarQubeCloudRegionRadioButtonGroup.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
-      var euRegionRadioSelector = new Button(sonarQubeCloudRegionRadioButtonGroup, SWT.RADIO);
-      euRegionRadioSelector.setText("EU - sonarcloud.io");
-      var usRegionRadioSelector = new Button(sonarQubeCloudRegionRadioButtonGroup, SWT.RADIO);
-      usRegionRadioSelector.setText("US - sonarqube.us");
-      
-      sonarCloudButton.addSelectionListener(new SelectionListener() {
-        @Override
-        public void widgetSelected(SelectionEvent e) {
-          euRegionRadioSelector.setEnabled(true);
-          usRegionRadioSelector.setEnabled(true);
-        }
-        
-        @Override
-        public void widgetDefaultSelected(SelectionEvent e) {
-          // No-op
-        }
-      });
-      
-      // Disable region selector buttons for SonarQube Server
-      sonarQubeButton.addSelectionListener(new SelectionListener() {
-        @Override
-        public void widgetSelected(SelectionEvent e) {
-          euRegionRadioSelector.setEnabled(false);
-          usRegionRadioSelector.setEnabled(false);
-        }
-        
-        @Override
-        public void widgetDefaultSelected(SelectionEvent e) {
-          // No-op
-        }
-      });
-      
-      var sonarCloudRegionSelectionEU = WidgetPropertiesCompat.buttonSelection().observe(euRegionRadioSelector);
-      var sonarCloudRegionSelectionUS = WidgetPropertiesCompat.buttonSelection().observe(usRegionRadioSelector);
-      
-      var sonarCloudRegionSelectObservable = new SelectObservableValue<>(ServerConnectionModel.SonarCloudRegion.class);
-      
-      sonarCloudRegionSelectObservable.addOption(ServerConnectionModel.SonarCloudRegion.EU, sonarCloudRegionSelectionEU);
-      sonarCloudRegionSelectObservable.addOption(ServerConnectionModel.SonarCloudRegion.US, sonarCloudRegionSelectionUS);
-      
-      dataBindingContext.bindValue(sonarCloudRegionSelectObservable, PojoPropertiesCompat.value(ServerConnectionModel.PROPERTY_SONARCLOUD_REGION).observe(model));
+    var sonarQubeCloudRegionRadioButtonGroup = new Composite(radioButtonGroupContainer, SWT.NONE);
+    var sonarQubeCloudRegionRadioButtonGroupLayout = new GridLayout();
+    sonarQubeCloudRegionRadioButtonGroupLayout.numColumns = 1;
+    sonarQubeCloudRegionRadioButtonGroup.setLayout(sonarQubeCloudRegionRadioButtonGroupLayout);
+    sonarQubeCloudRegionRadioButtonGroup.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 2, 1));
+    var euRegionRadioSelector = new Button(sonarQubeCloudRegionRadioButtonGroup, SWT.RADIO);
+    euRegionRadioSelector.setText("EU - sonarcloud.io");
+    var usRegionRadioSelector = new Button(sonarQubeCloudRegionRadioButtonGroup, SWT.RADIO);
+    usRegionRadioSelector.setText("US - sonarqube.us (invite-only)");
 
-    }
+    sonarCloudButton.addSelectionListener(new SelectionListener() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        euRegionRadioSelector.setEnabled(true);
+        usRegionRadioSelector.setEnabled(true);
+      }
+
+      @Override
+      public void widgetDefaultSelected(SelectionEvent e) {
+        // No-op
+      }
+    });
+
+    // Disable region selector buttons for SonarQube Server
+    sonarQubeButton.addSelectionListener(new SelectionListener() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        euRegionRadioSelector.setEnabled(false);
+        usRegionRadioSelector.setEnabled(false);
+      }
+
+      @Override
+      public void widgetDefaultSelected(SelectionEvent e) {
+        // No-op
+      }
+    });
+
+    var sonarCloudRegionSelectionEU = WidgetPropertiesCompat.buttonSelection().observe(euRegionRadioSelector);
+    var sonarCloudRegionSelectionUS = WidgetPropertiesCompat.buttonSelection().observe(usRegionRadioSelector);
+
+    var sonarCloudRegionSelectObservable = new SelectObservableValue<>(ServerConnectionModel.SonarCloudRegion.class);
+
+    sonarCloudRegionSelectObservable.addOption(ServerConnectionModel.SonarCloudRegion.EU, sonarCloudRegionSelectionEU);
+    sonarCloudRegionSelectObservable.addOption(ServerConnectionModel.SonarCloudRegion.US, sonarCloudRegionSelectionUS);
+
+    dataBindingContext.bindValue(sonarCloudRegionSelectObservable,
+      PojoPropertiesCompat.value(ServerConnectionModel.PROPERTY_SONARCLOUD_REGION).observe(model));
     
     var comparisonLabel = new Link(radioButtonGroupContainer, SWT.WRAP);
     comparisonLabel.setText("Explore SonarQube Cloud with our <a>Free tier</a>.");

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencePage.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencePage.java
@@ -119,12 +119,6 @@ public class SonarLintPreferencePage extends FieldEditorPreferencePage implement
 
     PlatformUtils.createHorizontalSpacer(getFieldEditorParent(), 1);
 
-    addField(new BooleanFieldEditor(SonarLintGlobalConfiguration.PREF_SHOW_REGION_SELECTOR,
-      "Show region selection for SonarQube Cloud",
-      getFieldEditorParent()));
-
-    PlatformUtils.createHorizontalSpacer(getFieldEditorParent(), 1);
-
     var powerUserLabel = new Link(getFieldEditorParent(), SWT.NONE);
     powerUserLabel.setText("This section targets power users who want to tweak SonarQube for Eclipse even more. "
       + "Please refer to <a>the documentation</a>.");

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencesInitializer.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/preferences/SonarLintPreferencesInitializer.java
@@ -39,7 +39,6 @@ public class SonarLintPreferencesInitializer extends AbstractPreferenceInitializ
     node.putBoolean(SonarLintGlobalConfiguration.PREF_ISSUE_ONLY_NEW_CODE, false);
     node.put(SonarLintGlobalConfiguration.PREF_EXTRA_ARGS, SonarLintGlobalConfiguration.PREF_DEFAULT);
     node.put(SonarLintGlobalConfiguration.PREF_TEST_FILE_GLOB_PATTERNS, SonarLintGlobalConfiguration.PREF_TEST_FILE_GLOB_PATTERNS_DEFAULT);
-    node.putBoolean(SonarLintGlobalConfiguration.PREF_SHOW_REGION_SELECTOR, false);
   }
 
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **UI & Configuration:**
    - Removed `SonarLintGlobalConfiguration.shouldShowRegionSelection()` check to make the SonarQube Cloud region selection unconditional in `ConnectionTypeWizardPage.java`
    - Cleaned up preference definitions and integration tests related to the region selection toggle

<sub>This will update automatically on new commits.</sub>