### PR TITLE
Added asyncExec guard for autobuild disabled popup

### DIFF
--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoAutomaticBuildWarningPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoAutomaticBuildWarningPopup.java
@@ -70,13 +70,15 @@ public class NoAutomaticBuildWarningPopup extends AbstractSonarLintPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotIgnored() {
-    if (ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding()
-      || PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)
-      || SonarLintGlobalConfiguration.noAutomaticBuildWarning() ) {
+    if (!shouldShowPopup()) {
       return;
     }
 
     Display.getDefault().asyncExec(() -> {
+      if (!shouldShowPopup()) {
+        return;
+      }
+      
       PopupUtils.addCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
 
       var popup = new NoAutomaticBuildWarningPopup();
@@ -84,5 +86,11 @@ public class NoAutomaticBuildWarningPopup extends AbstractSonarLintPopup {
       popup.setDelayClose(0L);
       popup.open();
     });
+  }
+  
+  private static boolean shouldShowPopup() {
+    return !ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding()
+        && !PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)
+        && !SonarLintGlobalConfiguration.noAutomaticBuildWarning();
   }
 }


### PR DESCRIPTION
### Problem description

When Autobuilding is disabled, Sonar shows a popup informing the user that results may be inaccurate. However, if multiple build commands are issued at the same time, it occasionally happens that this popup is shown multiple times (sadly we could not find a reliable reproduction for this).

<img width="523" height="866" alt="image" src="https://github.com/user-attachments/assets/5f853359-4375-4bb3-9e27-ccfa28b2a8a0" />

Looking into the code shows that the cause of this problem happens in `NoAutomaticBuildWarningPopup.displayPopupIfNotIgnored()`:

<img width="727" height="263" alt="image" src="https://github.com/user-attachments/assets/f45a213e-6926-442f-a779-27ecdf74c11e" />

Checking `PopupUtils.popupCurrentlyDisplayed(Class<? extends AbstractNotificationPopup>)` should guard against this popup being shown multiple times. However, this method is not checked again by the time the asynchronously scheduled runnable is actually executed, which leads to the described problem (This can also be reproduced by calling `NoAutomaticBuildWarningPopup.displayPopupIfNotIgnored()` in a loop repeatedly).

### Proposed solution

This PR combines the `isAutoBuilding()`, `popupCurrentlyDisplayed(...)` and `noAutomaticBuildWarning()` checks into one method which is re-checked inside the async runnable, guarding against the popup being shown multiple times.

### Further information

> Provide a unit test for any code you changed

I could not find a unit test bundle for this popup.