### PR TITLE
SLE-1599 Update SLCore to 11.9.0.86162

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <tycho.version>4.0.12</tycho.version>
 
     <!-- Sloop embedded CLI version for fragment projects -->
-    <sloop.version>11.9.0.86120</sloop.version>
+    <sloop.version>11.9.0.86162</sloop.version>
 
     <!-- SonarQube analysis -->
     <sonar.java.source>11</sonar.java.source>

--- a/target-platforms/commons-build.target
+++ b/target-platforms/commons-build.target
@@ -12,7 +12,7 @@
         <dependency>
           <groupId>org.sonarsource.sonarlint.core</groupId>
           <artifactId>sonarlint-java-client-osgi</artifactId>
-          <version>11.9.0.86120</version>
+          <version>11.9.0.86162</version>
           <type>jar</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Dependencies:**
    - Updated `sonarlint-java-client-osgi` version to `11.9.0.86162` in `commons-build.target`
    - Bumped embedded Sloop CLI version to `11.9.0.86162` in `pom.xml`

<sub>This will update automatically on new commits.</sub>