### PR TITLE
SLE-1609 Prevent duplicate Autobuild-disabled popup when multiple analyses run

### DIFF
--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/util/PopupUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/util/PopupUtilsTest.java
@@ -25,8 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Test;
-import org.sonarlint.eclipse.ui.internal.popup.NoAutomaticBuildWarningPopup;
-import org.sonarlint.eclipse.ui.internal.popup.ReleaseNotesPopup;
+import org.sonarlint.eclipse.ui.internal.notifications.AbstractNotificationPopup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,8 +33,8 @@ public class PopupUtilsTest {
 
   @After
   public void tearDown() {
-    PopupUtils.removeCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
-    PopupUtils.removeCurrentlyDisplayedPopup(ReleaseNotesPopup.class);
+    PopupUtils.removeCurrentlyDisplayedPopup(TestPopupA.class);
+    PopupUtils.removeCurrentlyDisplayedPopup(TestPopupB.class);
   }
 
   @Test
@@ -45,14 +44,14 @@ public class PopupUtilsTest {
     var shown = new AtomicInteger();
 
     for (var i = 0; i < 5; i++) {
-      PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, fakeAsyncExec);
+      PopupUtils.scheduleAsyncDisplay(TestPopupA.class, () -> true, shown::incrementAndGet, fakeAsyncExec);
     }
 
     assertThat(pending).hasSize(5);
     pending.forEach(Runnable::run);
 
     assertThat(shown.get()).isEqualTo(1);
-    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isTrue();
+    assertThat(PopupUtils.popupCurrentlyDisplayed(TestPopupA.class)).isTrue();
   }
 
   @Test
@@ -60,8 +59,8 @@ public class PopupUtilsTest {
     var pending = new ArrayList<Runnable>();
     var shown = new AtomicInteger();
 
-    PopupUtils.addCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
-    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, pending::add);
+    PopupUtils.addCurrentlyDisplayedPopup(TestPopupA.class);
+    PopupUtils.scheduleAsyncDisplay(TestPopupA.class, () -> true, shown::incrementAndGet, pending::add);
 
     assertThat(pending).isEmpty();
     assertThat(shown.get()).isZero();
@@ -72,7 +71,7 @@ public class PopupUtilsTest {
     var pending = new ArrayList<Runnable>();
     var shown = new AtomicInteger();
 
-    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> false, shown::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(TestPopupA.class, () -> false, shown::incrementAndGet, pending::add);
 
     assertThat(pending).isEmpty();
     assertThat(shown.get()).isZero();
@@ -84,13 +83,13 @@ public class PopupUtilsTest {
     var shown = new AtomicInteger();
     var shouldShow = new AtomicBoolean(true);
 
-    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, shouldShow::get, shown::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(TestPopupA.class, shouldShow::get, shown::incrementAndGet, pending::add);
 
     shouldShow.set(false);
     pending.forEach(Runnable::run);
 
     assertThat(shown.get()).isZero();
-    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isFalse();
+    assertThat(PopupUtils.popupCurrentlyDisplayed(TestPopupA.class)).isFalse();
   }
 
   @Test
@@ -98,24 +97,37 @@ public class PopupUtilsTest {
     var pending = new ArrayList<Runnable>();
     var shown = new AtomicInteger();
 
-    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(TestPopupA.class, () -> true, shown::incrementAndGet, pending::add);
     pending.forEach(Runnable::run);
 
     assertThat(shown.get()).isEqualTo(1);
-    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isTrue();
+    assertThat(PopupUtils.popupCurrentlyDisplayed(TestPopupA.class)).isTrue();
   }
 
   @Test
   public void can_show_different_popup_types_independently() {
     var pending = new ArrayList<Runnable>();
-    var shownAutobuild = new AtomicInteger();
-    var shownReleaseNotes = new AtomicInteger();
+    var shownA = new AtomicInteger();
+    var shownB = new AtomicInteger();
 
-    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shownAutobuild::incrementAndGet, pending::add);
-    PopupUtils.scheduleAsyncDisplay(ReleaseNotesPopup.class, () -> true, shownReleaseNotes::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(TestPopupA.class, () -> true, shownA::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(TestPopupB.class, () -> true, shownB::incrementAndGet, pending::add);
     pending.forEach(Runnable::run);
 
-    assertThat(shownAutobuild.get()).isEqualTo(1);
-    assertThat(shownReleaseNotes.get()).isEqualTo(1);
+    assertThat(shownA.get()).isEqualTo(1);
+    assertThat(shownB.get()).isEqualTo(1);
+  }
+
+  /** Type tokens only — never instantiated, so they cannot collide with production popup state. */
+  private static final class TestPopupA extends AbstractNotificationPopup {
+    private TestPopupA() {
+      super(null);
+    }
+  }
+
+  private static final class TestPopupB extends AbstractNotificationPopup {
+    private TestPopupB() {
+      super(null);
+    }
   }
 }

--- a/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/util/PopupUtilsTest.java
+++ b/org.sonarlint.eclipse.core.tests/src/test/java/org/sonarlint/eclipse/ui/internal/util/PopupUtilsTest.java
@@ -1,0 +1,121 @@
+/*
+ * SonarLint for Eclipse
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.eclipse.ui.internal.util;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Test;
+import org.sonarlint.eclipse.ui.internal.popup.NoAutomaticBuildWarningPopup;
+import org.sonarlint.eclipse.ui.internal.popup.ReleaseNotesPopup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PopupUtilsTest {
+
+  @After
+  public void tearDown() {
+    PopupUtils.removeCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
+    PopupUtils.removeCurrentlyDisplayedPopup(ReleaseNotesPopup.class);
+  }
+
+  @Test
+  public void does_not_open_popup_twice_when_scheduled_repeatedly_before_ui_thread_runs() {
+    var pending = new ArrayList<Runnable>();
+    Consumer<Runnable> fakeAsyncExec = pending::add;
+    var shown = new AtomicInteger();
+
+    for (var i = 0; i < 5; i++) {
+      PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, fakeAsyncExec);
+    }
+
+    assertThat(pending).hasSize(5);
+    pending.forEach(Runnable::run);
+
+    assertThat(shown.get()).isEqualTo(1);
+    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isTrue();
+  }
+
+  @Test
+  public void does_not_schedule_when_popup_already_displayed() {
+    var pending = new ArrayList<Runnable>();
+    var shown = new AtomicInteger();
+
+    PopupUtils.addCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, pending::add);
+
+    assertThat(pending).isEmpty();
+    assertThat(shown.get()).isZero();
+  }
+
+  @Test
+  public void does_not_schedule_when_should_show_is_false() {
+    var pending = new ArrayList<Runnable>();
+    var shown = new AtomicInteger();
+
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> false, shown::incrementAndGet, pending::add);
+
+    assertThat(pending).isEmpty();
+    assertThat(shown.get()).isZero();
+  }
+
+  @Test
+  public void does_not_open_when_should_show_becomes_false_before_ui_thread_runs() {
+    var pending = new ArrayList<Runnable>();
+    var shown = new AtomicInteger();
+    var shouldShow = new AtomicBoolean(true);
+
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, shouldShow::get, shown::incrementAndGet, pending::add);
+
+    shouldShow.set(false);
+    pending.forEach(Runnable::run);
+
+    assertThat(shown.get()).isZero();
+    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isFalse();
+  }
+
+  @Test
+  public void opens_popup_when_conditions_still_hold() {
+    var pending = new ArrayList<Runnable>();
+    var shown = new AtomicInteger();
+
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shown::incrementAndGet, pending::add);
+    pending.forEach(Runnable::run);
+
+    assertThat(shown.get()).isEqualTo(1);
+    assertThat(PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)).isTrue();
+  }
+
+  @Test
+  public void can_show_different_popup_types_independently() {
+    var pending = new ArrayList<Runnable>();
+    var shownAutobuild = new AtomicInteger();
+    var shownReleaseNotes = new AtomicInteger();
+
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, () -> true, shownAutobuild::incrementAndGet, pending::add);
+    PopupUtils.scheduleAsyncDisplay(ReleaseNotesPopup.class, () -> true, shownReleaseNotes::incrementAndGet, pending::add);
+    pending.forEach(Runnable::run);
+
+    assertThat(shownAutobuild.get()).isEqualTo(1);
+    assertThat(shownReleaseNotes.get()).isEqualTo(1);
+  }
+}

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/InvalidTokenPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/InvalidTokenPopup.java
@@ -21,7 +21,6 @@ package org.sonarlint.eclipse.ui.internal.popup;
 
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.internal.engine.connected.ConnectionFacade;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
 import org.sonarlint.eclipse.ui.internal.binding.wizard.connection.ServerConnectionWizard;
@@ -71,13 +70,7 @@ public class InvalidTokenPopup extends AbstractSonarLintPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotIgnored(ConnectionFacade facade) {
-    if (PopupUtils.popupCurrentlyDisplayed(InvalidTokenPopup.class)) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(InvalidTokenPopup.class);
-
+    PopupUtils.scheduleAsyncDisplay(InvalidTokenPopup.class, () -> {
       var popup = new InvalidTokenPopup(facade);
       popup.setFadingEnabled(false);
       popup.setDelayClose(0L);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/LanguageFromConnectedModePopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/LanguageFromConnectedModePopup.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.analysis.SonarLintLanguage;
 import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 import org.sonarlint.eclipse.core.internal.SonarLintCorePlugin;
@@ -99,18 +98,13 @@ public class LanguageFromConnectedModePopup extends AbstractSonarLintPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotIgnored(ISonarLintProject project, List<SonarLintLanguage> languages) {
-    if (languages.isEmpty() || PopupUtils.popupCurrentlyDisplayed(LanguageFromConnectedModePopup.class)
-      || SonarLintGlobalConfiguration.ignoreMissingFeatureNotifications()) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(LanguageFromConnectedModePopup.class);
-
-      var popup = new LanguageFromConnectedModePopup(project, languages);
-      popup.setFadingEnabled(false);
-      popup.setDelayClose(0L);
-      popup.open();
-    });
+    PopupUtils.scheduleAsyncDisplay(LanguageFromConnectedModePopup.class,
+      () -> !languages.isEmpty() && !SonarLintGlobalConfiguration.ignoreMissingFeatureNotifications(),
+      () -> {
+        var popup = new LanguageFromConnectedModePopup(project, languages);
+        popup.setFadingEnabled(false);
+        popup.setDelayClose(0L);
+        popup.open();
+      });
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NewerVersionAvailablePopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NewerVersionAvailablePopup.java
@@ -19,7 +19,6 @@
  */
 package org.sonarlint.eclipse.ui.internal.popup;
 
-import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 import org.sonarlint.eclipse.ui.internal.job.TriggerUpdateAction;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
@@ -50,13 +49,7 @@ public class NewerVersionAvailablePopup extends AbstractSonarLintVersionPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotAlreadyShown(String version) {
-    if (PopupUtils.popupCurrentlyDisplayed(NewerVersionAvailablePopup.class)) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(NewerVersionAvailablePopup.class);
-
+    PopupUtils.scheduleAsyncDisplay(NewerVersionAvailablePopup.class, () -> {
       var popup = new NewerVersionAvailablePopup(version);
       popup.setFadingEnabled(false);
       popup.setDelayClose(0L);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoAutomaticBuildWarningPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoAutomaticBuildWarningPopup.java
@@ -22,7 +22,6 @@ package org.sonarlint.eclipse.ui.internal.popup;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.sonarlint.eclipse.core.internal.preferences.SonarLintGlobalConfiguration;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
@@ -70,19 +69,16 @@ public class NoAutomaticBuildWarningPopup extends AbstractSonarLintPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotIgnored() {
-    if (ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding()
-      || PopupUtils.popupCurrentlyDisplayed(NoAutomaticBuildWarningPopup.class)
-      || SonarLintGlobalConfiguration.noAutomaticBuildWarning() ) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(NoAutomaticBuildWarningPopup.class);
-
+    PopupUtils.scheduleAsyncDisplay(NoAutomaticBuildWarningPopup.class, NoAutomaticBuildWarningPopup::shouldShowPopup, () -> {
       var popup = new NoAutomaticBuildWarningPopup();
       popup.setFadingEnabled(false);
       popup.setDelayClose(0L);
       popup.open();
     });
+  }
+
+  private static boolean shouldShowPopup() {
+    return !ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding()
+      && !SonarLintGlobalConfiguration.noAutomaticBuildWarning();
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoBindingSuggestionFoundPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/NoBindingSuggestionFoundPopup.java
@@ -21,7 +21,6 @@ package org.sonarlint.eclipse.ui.internal.popup;
 
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.core.documentation.SonarLintDocumentation;
 import org.sonarlint.eclipse.ui.internal.SonarLintImages;
 import org.sonarlint.eclipse.ui.internal.util.BrowserUtils;
@@ -74,13 +73,7 @@ public class NoBindingSuggestionFoundPopup extends AbstractSonarLintPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotIgnored(String configurationScopeId, boolean isSonarCloud) {
-    if (PopupUtils.popupCurrentlyDisplayed(NoBindingSuggestionFoundPopup.class)) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(NoBindingSuggestionFoundPopup.class);
-
+    PopupUtils.scheduleAsyncDisplay(NoBindingSuggestionFoundPopup.class, () -> {
       var popup = new NoBindingSuggestionFoundPopup(configurationScopeId, isSonarCloud);
       popup.setFadingEnabled(false);
       popup.setDelayClose(0L);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/ReleaseNotesPopup.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/popup/ReleaseNotesPopup.java
@@ -19,7 +19,6 @@
  */
 package org.sonarlint.eclipse.ui.internal.popup;
 
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.sonarlint.eclipse.ui.internal.properties.ReleaseNotesPage;
 import org.sonarlint.eclipse.ui.internal.util.PopupUtils;
@@ -47,13 +46,7 @@ public class ReleaseNotesPopup extends AbstractSonarLintVersionPopup {
 
   /** This way everyone calling the pop-up does not have to handle it being actually displayed or not */
   public static void displayPopupIfNotAlreadyShown() {
-    if (PopupUtils.popupCurrentlyDisplayed(ReleaseNotesPopup.class)) {
-      return;
-    }
-
-    Display.getDefault().asyncExec(() -> {
-      PopupUtils.addCurrentlyDisplayedPopup(ReleaseNotesPopup.class);
-
+    PopupUtils.scheduleAsyncDisplay(ReleaseNotesPopup.class, () -> {
       var popup = new ReleaseNotesPopup();
       popup.setFadingEnabled(false);
       popup.setDelayClose(0L);

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PopupUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PopupUtils.java
@@ -22,6 +22,9 @@ package org.sonarlint.eclipse.ui.internal.util;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import org.eclipse.swt.widgets.Display;
 import org.sonarlint.eclipse.ui.internal.notifications.AbstractNotificationPopup;
 
 /** Utility used for reducing stacked up notifications */
@@ -36,11 +39,56 @@ public class PopupUtils {
     return popupsCurrentlyDisplayed.contains(popupClass);
   }
 
-  public static void addCurrentlyDisplayedPopup(Class<? extends AbstractNotificationPopup> popupClass) {
-    popupsCurrentlyDisplayed.add(popupClass);
+  /**
+   * @return {@code true} if the popup was not already marked as displayed
+   */
+  public static boolean addCurrentlyDisplayedPopup(Class<? extends AbstractNotificationPopup> popupClass) {
+    return popupsCurrentlyDisplayed.add(popupClass);
   }
 
   public static void removeCurrentlyDisplayedPopup(Class<? extends AbstractNotificationPopup> popupClass) {
     popupsCurrentlyDisplayed.remove(popupClass);
+  }
+
+  /**
+   * Schedule showing a popup on the SWT UI thread if it is not already displayed.
+   * <p>
+   * Conditions are re-checked when the runnable actually runs, because
+   * {@link Display#asyncExec(Runnable)} is invoked at the next reasonable opportunity and the
+   * application state may have changed in the meantime (e.g. multiple analysis events queuing the
+   * same popup).
+   */
+  public static void scheduleAsyncDisplay(Class<? extends AbstractNotificationPopup> popupClass, Runnable openPopup) {
+    scheduleAsyncDisplay(popupClass, () -> true, openPopup);
+  }
+
+  /**
+   * Schedule showing a popup on the SWT UI thread if {@code shouldShow} is true and the popup is
+   * not already displayed. Both conditions are re-checked when the runnable actually runs.
+   */
+  public static void scheduleAsyncDisplay(Class<? extends AbstractNotificationPopup> popupClass, BooleanSupplier shouldShow,
+    Runnable openPopup) {
+    scheduleAsyncDisplay(popupClass, shouldShow, openPopup, Display.getDefault()::asyncExec);
+  }
+
+  /**
+   * Same as {@link #scheduleAsyncDisplay(Class, BooleanSupplier, Runnable)} but with an injectable UI
+   * executor so callers (including tests) can simulate {@code Display.asyncExec} without an SWT Display.
+   */
+  public static void scheduleAsyncDisplay(Class<? extends AbstractNotificationPopup> popupClass, BooleanSupplier shouldShow,
+    Runnable openPopup, Consumer<Runnable> uiExecutor) {
+    if (!canShow(popupClass, shouldShow)) {
+      return;
+    }
+    uiExecutor.accept(() -> {
+      if (!shouldShow.getAsBoolean() || !addCurrentlyDisplayedPopup(popupClass)) {
+        return;
+      }
+      openPopup.run();
+    });
+  }
+
+  private static boolean canShow(Class<? extends AbstractNotificationPopup> popupClass, BooleanSupplier shouldShow) {
+    return shouldShow.getAsBoolean() && !popupCurrentlyDisplayed(popupClass);
   }
 }

--- a/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PopupUtils.java
+++ b/org.sonarlint.eclipse.ui/src/org/sonarlint/eclipse/ui/internal/util/PopupUtils.java
@@ -68,7 +68,7 @@ public class PopupUtils {
    */
   public static void scheduleAsyncDisplay(Class<? extends AbstractNotificationPopup> popupClass, BooleanSupplier shouldShow,
     Runnable openPopup) {
-    scheduleAsyncDisplay(popupClass, shouldShow, openPopup, Display.getDefault()::asyncExec);
+    scheduleAsyncDisplay(popupClass, shouldShow, openPopup, runnable -> Display.getDefault().asyncExec(runnable));
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SLE-1609](https://sonarsource.atlassian.net/browse/SLE-1609) / [community thread 187161](https://community.sonarsource.com/t/autobuild-disabled-popup-sometimes-pops-up-multiple-times/187161).

### Problem

When Autobuilding is disabled, SonarQube for Eclipse shows a popup that results may be inaccurate. If several build/analysis events are issued at the same time (for example after a Git branch switch), that popup can appear more than once.

`PopupUtils.popupCurrentlyDisplayed(...)` was only checked *before* scheduling `Display.asyncExec`. SWT runs that runnable at the next reasonable opportunity, so the application state can change in between. Calling `displayPopupIfNotIgnored()` in a tight loop reproduces the same race.

The same missing re-check existed for `InvalidTokenPopup`, `LanguageFromConnectedModePopup`, `NewerVersionAvailablePopup`, `NoBindingSuggestionFoundPopup`, and `ReleaseNotesPopup`.

This is the approach from [PR #1098](https://github.com/SonarSource/sonarlint-eclipse/pull/1098) by @r-mennig, generalized so every async notification popup is covered, with unit tests.

### Solution

- Add `PopupUtils.scheduleAsyncDisplay(...)`, which re-checks `shouldShow` and atomically marks the popup as displayed *inside* the UI-thread runnable.
- Use that helper from all async popups listed above.
- Cover the race (and related condition changes) in `PopupUtilsTest` with an injectable UI executor, so tests do not need an SWT `Display`.

Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-eclipse/blob/master/docs/contributing.md).

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95ca1252-7786-4723-b73b-f8f100775bea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95ca1252-7786-4723-b73b-f8f100775bea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[SLE-1609]: https://sonarsource.atlassian.net/browse/SLE-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ