### PR TITLE
SLE-1604 SLE-1605 SLE-1606 SLE-1607 SLE-1608 SLE-1610 12.8 analyzer updates

### DIFF
--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -87,7 +87,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>13.8.0.44569</version>
+                  <version>13.9.0.44793</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -99,7 +99,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.30.0.36259</version>
+                  <version>5.31.0.36502</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -99,7 +99,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.29.0.35837</version>
+                  <version>5.30.0.36259</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -75,7 +75,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.java</groupId>
                   <artifactId>sonar-java-plugin</artifactId>
-                  <version>8.40.0.46617</version>
+                  <version>8.41.0.47177</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -87,7 +87,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>13.7.0.44407</version>
+                  <version>13.8.0.44569</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/org.sonarlint.eclipse.core/pom.xml
+++ b/org.sonarlint.eclipse.core/pom.xml
@@ -117,7 +117,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.text</groupId>
                   <artifactId>sonar-text-plugin</artifactId>
-                  <version>2.48.0.12108</version>
+                  <version>2.49.0.12346</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -26,7 +26,7 @@
     <ul>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407">13.7</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.40.0.46617">8.40</a></li>
-        <li>Update Python analyzer -> 5.30</li>
+        <li>Update Python analyzer -> 5.31</li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -27,6 +27,7 @@
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407">13.7</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.41.0.47177">8.41</a></li>
         <li>Update Python analyzer -> 5.31</li>
+        <li>Update Text and Secrets analyzer -> 2.49</li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -26,6 +26,7 @@
     <ul>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407">13.7</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.40.0.46617">8.40</a></li>
+        <li>Update Python analyzer -> 5.30</li>
     </ul>
 </div>
 

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -24,7 +24,7 @@
         See the <a href="https://github.com/SonarSource/sonarlint-eclipse/releases">GitHub Release page</a>
     </p>
     <ul>
-        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.8.0.44569">13.8</a></li>
+        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.9.0.44793">13.9</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.41.0.47177">8.41</a></li>
         <li>Update Python analyzer -> 5.31</li>
         <li>Update Text and Secrets analyzer -> 2.49</li>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -24,7 +24,7 @@
         See the <a href="https://github.com/SonarSource/sonarlint-eclipse/releases">GitHub Release page</a>
     </p>
     <ul>
-        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407">13.7</a></li>
+        <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.8.0.44569">13.8</a></li>
         <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.41.0.47177">8.41</a></li>
         <li>Update Python analyzer -> 5.31</li>
         <li>Update Text and Secrets analyzer -> 2.49</li>

--- a/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
+++ b/org.sonarlint.eclipse.ui/intro/RELEASE_NOTES.html
@@ -25,7 +25,7 @@
     </p>
     <ul>
         <li>Update JS/TS/CSS analyzer -> <a href="https://github.com/SonarSource/SonarJS/releases/tag/13.7.0.44407">13.7</a></li>
-        <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.40.0.46617">8.40</a></li>
+        <li>Update Java analyzer -> <a href="https://github.com/SonarSource/sonar-java/releases/tag/8.41.0.47177">8.41</a></li>
         <li>Update Python analyzer -> 5.31</li>
     </ul>
 </div>


### PR DESCRIPTION
Analyzer updates for the 12.8 release.

- SLE-1604 Update python-enterprise to 5.30.0.36259
- SLE-1605 Update python-enterprise to 5.31.0.36502
- SLE-1606 Update java to 8.41.0.47177
- SLE-1607 Update text to 2.49.0.12346
- SLE-1608 Update javascript to 13.8.0.44569
- SLE-1610 Update javascript to 13.9.0.44793

🤖 Generated with [Claude Code](https://claude.com/claude-code)